### PR TITLE
Add warnings for numbers

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -690,6 +690,7 @@ the variables:
    single: PyExc_SyntaxWarning
    single: PyExc_UnicodeWarning
    single: PyExc_UserWarning
+   single: PyExc_Py3xWarning
 
 +------------------------------------------+---------------------------------+----------+
 | C Name                                   | Python Name                     | Notes    |
@@ -713,6 +714,8 @@ the variables:
 | :c:data:`PyExc_UnicodeWarning`           | :exc:`UnicodeWarning`           |          |
 +------------------------------------------+---------------------------------+----------+
 | :c:data:`PyExc_UserWarning`              | :exc:`UserWarning`              |          |
++------------------------------------------+---------------------------------+----------+
+| :c:data:`PyExc_3xWarning`                | :exc:`Py3xWarning`                |          |
 +------------------------------------------+---------------------------------+----------+
 
 Notes:

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -530,6 +530,10 @@ module for more information.
 
    .. versionadded:: 2.6
 
+.. exception:: Py3xWarning
+
+   Base class for warnings about 3.x compatibility.
+
 
 Exception hierarchy
 -------------------

--- a/Doc/library/warnings.rst
+++ b/Doc/library/warnings.rst
@@ -94,6 +94,9 @@ following warnings category classes are currently defined:
 | :exc:`BytesWarning`              | Base category for warnings related to         |
 |                                  | bytes and bytearray.                          |
 +----------------------------------+-----------------------------------------------+
+| :exc:`Py3xWarning`               | Base class for warnings about 3.x             |
+                                   | compatibility                                 |                         |
++----------------------------------+-----------------------------------------------+
 
 While these are technically built-in exceptions, they are documented here,
 because conceptually they belong to the warnings mechanism.

--- a/Include/pyerrors.h
+++ b/Include/pyerrors.h
@@ -177,6 +177,7 @@ PyAPI_DATA(PyObject *) PyExc_FutureWarning;
 PyAPI_DATA(PyObject *) PyExc_ImportWarning;
 PyAPI_DATA(PyObject *) PyExc_UnicodeWarning;
 PyAPI_DATA(PyObject *) PyExc_BytesWarning;
+PyAPI_DATA(PyObject *) PyExc_Py3xWarning;
 
 
 /* Convenience functions */

--- a/Lib/test/exception_hierarchy.txt
+++ b/Lib/test/exception_hierarchy.txt
@@ -45,6 +45,7 @@ BaseException
            +-- SyntaxWarning
            +-- UserWarning
            +-- FutureWarning
+           +-- Py3xWarning
 	   +-- ImportWarning
 	   +-- UnicodeWarning
 	   +-- BytesWarning

--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -65,6 +65,15 @@ class TokenTests(unittest.TestCase):
         else:
             self.fail('Weird maxint value %r' % maxint)
 
+        if sys.py3kwarning:
+            with warnings.catch_warnings():
+                warnings.filterwarnings('error', category=Py3xWarning)
+                with self.assertRaises(Py3xWarning) as oct:
+                    compile('032', '<test string>', 'eval')
+                self.assertIn("octal literals are not supported in 3.x;\n" 
+                              "drop the leading 0",
+                              str(oct.exception))
+
     def test_long_integers(self):
         x = 0L
         x = 0l

--- a/Lib/test/test_optparse.py
+++ b/Lib/test/test_optparse.py
@@ -23,6 +23,7 @@ from optparse import make_option, Option, \
      BadOptionError, OptionValueError, Values
 from optparse import _match_abbrev
 from optparse import _parse_num
+from test.test_support import run_unittest, check_py3k_warnings
 
 retype = type(re.compile(''))
 

--- a/Lib/test/test_optparse.py
+++ b/Lib/test/test_optparse.py
@@ -1654,6 +1654,16 @@ class TestParseNumber(BaseTest):
         self.assertParseFail(["-l", "0x12x"],
                              "option -l: invalid long integer value: '0x12x'")
 
+    def test_parse_num_3k_warnings(self):
+        expected = 'the L suffix is not supported in 3.x; simply drop the suffix, \
+                    or accept the auto fixer modifications'
+        with check_py3k_warnings((expected, Py3xWarning)):
+            x = 10L
+            y = 8L
+            z = x + y
+            a = x * y
+            b = x - y
+
 
 def test_main():
     test_support.run_unittest(__name__)

--- a/Misc/Vim/python.vim
+++ b/Misc/Vim/python.vim
@@ -92,6 +92,7 @@ if exists("python_highlight_exceptions")
   syn keyword pythonException    ReferenceError RuntimeError RuntimeWarning
   syn keyword pythonException    StandardError StopIteration SyntaxError
   syn keyword pythonException    SyntaxWarning SystemError SystemExit TabError
+  syn keyword pythonException    Py3xWarning SystemError SystemExit Warning
   syn keyword pythonException    TypeError UnboundLocalError UnicodeDecodeError
   syn keyword pythonException    UnicodeEncodeError UnicodeError
   syn keyword pythonException    UnicodeTranslateError UnicodeWarning

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -1982,6 +1982,13 @@ SimpleExtendsException(PyExc_Warning, SyntaxWarning,
 
 
 /*
+ *    3xWarning extends Warning
+ */
+SimpleExtendsException(PyExc_Warning, Py3xWarning,
+                       "Base class for warnings about 3.x compatibility.");
+
+
+/*
  *    RuntimeWarning extends Warning
  */
 SimpleExtendsException(PyExc_Warning, RuntimeWarning,
@@ -2104,6 +2111,7 @@ _PyExc_Init(void)
     PRE_INIT(ImportWarning)
     PRE_INIT(UnicodeWarning)
     PRE_INIT(BytesWarning)
+    PRE_INIT(Py3xWarning)
 
     m = Py_InitModule4("exceptions", functions, exceptions_doc,
         (PyObject *)NULL, PYTHON_API_VERSION);
@@ -2173,6 +2181,7 @@ _PyExc_Init(void)
     POST_INIT(ImportWarning)
     POST_INIT(UnicodeWarning)
     POST_INIT(BytesWarning)
+    POST_INIT(Py3xWarning)
 
     PyExc_MemoryErrorInst = BaseException_new(&_PyExc_MemoryError, NULL, NULL);
     if (!PyExc_MemoryErrorInst)

--- a/PC/os2emx/python27.def
+++ b/PC/os2emx/python27.def
@@ -819,6 +819,7 @@ EXPORTS
   "PyExc_DeprecationWarning"
   "PyExc_PendingDeprecationWarning"
   "PyExc_SyntaxWarning"
+  "PyExc_Py3xWarning"
   "PyExc_RuntimeWarning"
   "PyExc_FutureWarning"
   "PyExc_ImportWarning"

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1433,6 +1433,14 @@ tok_get(register struct tok_state *tok, char **p_start, char **p_end)
     /* Number */
     if (isdigit(c)) {
         if (c == '0') {
+            if (Py_Py3kWarningFlag) {
+                if (PyErr_WarnExplicit(PyExc_Py3xWarning,
+                                    "octal literals are not supported in 3.x;\n" 
+                                    "drop the leading 0",
+                                    tok->filename, tok->lineno, NULL, NULL)) {
+                    return NULL;
+                }
+            }
             /* Hex, octal or binary -- maybe. */
             c = tok_nextc(tok);
             if (c == '.')


### PR DESCRIPTION
This has several changes, after git playing games with me, I managed to split the commits instead of committing one long one, as I had done before.

*First commit*: Adds warnings for when the suffix "L" is used with numbers but also adds a custom Exception for our work suggested in the review of #2 , called `Py3xWarning`. I should have committed the exception separately though.
*Second commit*: Add warnings for octal literals. I fixed a test too