### PR TITLE
Add warnings for sorting and comparison

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -319,6 +319,12 @@ is a separate error indicator for each thread.
    and *registry* arguments may be set to *NULL* to get the default effect
    described there.
 
+.. c:function:: int PyErr_WarnExplicit_WithFix(PyObject *category, const char *message, const char *fix, const char *filename, int lineno, const char *module, PyObject *registry)
+
+   Issue a warning message and a potential fix.  This warning is the 
+   same as `PyErr_WarnExplicit` but adds a *fix* argument to allow 
+   for `Py3xWarning` warnings to suggest potential fixes for Python
+   3.x incompatible code.
 
 .. c:function:: int PyErr_WarnPy3k(char *message, int stacklevel)
 
@@ -715,7 +721,7 @@ the variables:
 +------------------------------------------+---------------------------------+----------+
 | :c:data:`PyExc_UserWarning`              | :exc:`UserWarning`              |          |
 +------------------------------------------+---------------------------------+----------+
-| :c:data:`PyExc_3xWarning`                | :exc:`Py3xWarning`                |          |
+| :c:data:`PyExc_3xWarning`                | :exc:`Py3xWarning`              |          |
 +------------------------------------------+---------------------------------+----------+
 
 Notes:

--- a/Doc/library/warnings.rst
+++ b/Doc/library/warnings.rst
@@ -95,7 +95,7 @@ following warnings category classes are currently defined:
 |                                  | bytes and bytearray.                          |
 +----------------------------------+-----------------------------------------------+
 | :exc:`Py3xWarning`               | Base class for warnings about 3.x             |
-                                   | compatibility                                 |                         |
+                                   | compatibility.                                 |                         |
 +----------------------------------+-----------------------------------------------+
 
 While these are technically built-in exceptions, they are documented here,

--- a/Include/warnings.h
+++ b/Include/warnings.h
@@ -7,6 +7,7 @@ extern "C" {
 PyAPI_FUNC(void) _PyWarnings_Init(void);
 
 PyAPI_FUNC(int) PyErr_WarnEx(PyObject *, const char *, Py_ssize_t);
+PyAPI_FUNC(int) PyErr_WarnEx_WithFix(PyObject *, const char *, const char *, Py_ssize_t);
 PyAPI_FUNC(int) PyErr_WarnExplicit(PyObject *, const char *, const char *, int,
                                     const char *, PyObject *);
 PyAPI_FUNC(int) PyErr_WarnExplicit_WithFix(PyObject *, const char *, const char *, const char *, int,

--- a/Include/warnings.h
+++ b/Include/warnings.h
@@ -9,6 +9,8 @@ PyAPI_FUNC(void) _PyWarnings_Init(void);
 PyAPI_FUNC(int) PyErr_WarnEx(PyObject *, const char *, Py_ssize_t);
 PyAPI_FUNC(int) PyErr_WarnExplicit(PyObject *, const char *, const char *, int,
                                     const char *, PyObject *);
+PyAPI_FUNC(int) PyErr_WarnExplicit_WithFix(PyObject *, const char *, const char *, const char *, int,
+                                    const char *, PyObject *);
 
 #define PyErr_WarnPy3k(msg, stacklevel) \
   (Py_Py3kWarningFlag ? PyErr_WarnEx(PyExc_DeprecationWarning, msg, stacklevel) : 0)

--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -66,14 +66,19 @@ class TokenTests(unittest.TestCase):
             self.fail('Weird maxint value %r' % maxint)
 
         if sys.py3kwarning:
-            with warnings.catch_warnings():
-                warnings.filterwarnings('error', category=Py3xWarning)
-                with self.assertRaises(Py3xWarning) as oct:
-                    compile('032', '<test string>', 'eval')
-                self.assertIn("octal literals are not supported in 3.x;\n" 
-                              "drop the leading 0",
-                              str(oct.exception))
-
+            with warnings.catch_warnings(record=True) as w:
+                warnings.filterwarnings('always', category=Py3xWarning)
+                self.assertEqual(034, 28)
+                self.assertEqual(01, 1)
+                for warning in w:
+                    self.assertTrue(Py3xWarning is w.category)
+                    self.assertEqual(str(w.message), "using just a '0' prefix for octal literals is not supported in 3.x: " \
+                                        "use the '0o' prefix for octal integers")
+                    self.assertEqual(len(w), 2)
+                    self.assertIn("using just a '0' prefix for octal literals is not supported in 3.x:: \n" 
+                                    "use the '0o' prefix for octal integers",
+                                    str(oct.exception))
+                              
     def test_long_integers(self):
         x = 0L
         x = 0l

--- a/Lib/test/test_optparse.py
+++ b/Lib/test/test_optparse.py
@@ -23,7 +23,7 @@ from optparse import make_option, Option, \
      BadOptionError, OptionValueError, Values
 from optparse import _match_abbrev
 from optparse import _parse_num
-from test.test_support import run_unittest, check_py3k_warnings
+from test.test_support import run_unittest, check_py3k_warnings, warnings
 
 retype = type(re.compile(''))
 
@@ -1656,14 +1656,20 @@ class TestParseNumber(BaseTest):
                              "option -l: invalid long integer value: '0x12x'")
 
     def test_parse_num_3k_warnings(self):
-        expected = 'the L suffix is not supported in 3.x; simply drop the suffix, \
-                    or accept the auto fixer modifications'
-        with check_py3k_warnings((expected, Py3xWarning)):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings("always", "the L suffix is not supported in 3.x: \
+                                    drop the suffix",
+                                Py3xWarning)
             x = 10L
             y = 8L
             z = x + y
             a = x * y
             b = x - y
+            for warning in w:
+                self.assertTrue(Py3xWarning is w.category)
+                self.assertEqual(str(w.message), "the L suffix is not supported in 3.x: " \
+                                 "drop the suffix")
+                self.assertEqual(len(w), 5)
 
 
 def test_main():

--- a/Lib/test/test_sort.py
+++ b/Lib/test/test_sort.py
@@ -278,6 +278,11 @@ def test_main(verbose=None):
             ("the cmp argument is not supported", DeprecationWarning)):
         test_support.run_unittest(*test_classes)
 
+    with test_support.check_py3k_warnings(
+            ("the cmp method is not supported in 3.x;"
+             "use the new rich comparison functions", Py3xWarning)):
+        test_support.run_unittest(*test_classes)
+
         # verify reference counting
         if verbose and hasattr(sys, "gettotalrefcount"):
             import gc

--- a/Lib/test/test_sort.py
+++ b/Lib/test/test_sort.py
@@ -279,8 +279,8 @@ def test_main(verbose=None):
         test_support.run_unittest(*test_classes)
 
     with test_support.check_py3k_warnings(
-            ("the cmp method is not supported in 3.x;"
-             "use the new rich comparison functions", Py3xWarning)):
+            ("the cmp method is not supported in 3.x"
+             "implement the function to a utility library", Py3xWarning)):
         test_support.run_unittest(*test_classes)
 
         # verify reference counting

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -1982,7 +1982,8 @@ SimpleExtendsException(PyExc_Warning, SyntaxWarning,
 
 
 /*
- *    3xWarning extends Warning
+ *    Py3xWarning extends Warning
+ *    XXX(nanjekyejoannah): Suppress this warning for legacy tests for now
  */
 SimpleExtendsException(PyExc_Warning, Py3xWarning,
                        "Base class for warnings about 3.x compatibility.");

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -820,6 +820,12 @@ do_cmp(PyObject *v, PyObject *w)
     int c;
     cmpfunc f;
 
+    if (Py_Py3kWarningFlag &&
+        PyErr_WarnEx(PyExc_Py3xWarning, "the cmp method is not supported in 3.x;"
+        "use the new rich comparison functions", 1) < 0) {
+        return 0;
+    }
+
     if (v->ob_type == w->ob_type
         && (f = v->ob_type->tp_compare) != NULL) {
         c = (*f)(v, w);

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -820,12 +820,6 @@ do_cmp(PyObject *v, PyObject *w)
     int c;
     cmpfunc f;
 
-    if (Py_Py3kWarningFlag &&
-        PyErr_WarnEx(PyExc_Py3xWarning, "the cmp method is not supported in 3.x;"
-        "use the new rich comparison functions", 1) < 0) {
-        return 0;
-    }
-
     if (v->ob_type == w->ob_type
         && (f = v->ob_type->tp_compare) != NULL) {
         c = (*f)(v, w);
@@ -865,6 +859,12 @@ int
 PyObject_Compare(PyObject *v, PyObject *w)
 {
     int result;
+
+    if (Py_Py3kWarningFlag &&
+        PyErr_WarnEx_WithFix(PyExc_Py3xWarning, "the cmp method is not supported in 3.x",
+        "implement the function to a utility library", 1) < 0) {
+        return 0;
+    }
 
     if (v == NULL || w == NULL) {
         PyErr_BadInternalCall();

--- a/PC/os2emx/python27.def
+++ b/PC/os2emx/python27.def
@@ -914,6 +914,7 @@ EXPORTS
   "_PyErr_BadInternalCall"
   "PyErr_Warn"
   "PyErr_WarnExplicit"
+  "PyErr_WarnExplicit_WithFix"
 
 ; From python27_s.lib(frozen)
   "PyImport_FrozenModules"

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1433,14 +1433,6 @@ tok_get(register struct tok_state *tok, char **p_start, char **p_end)
     /* Number */
     if (isdigit(c)) {
         if (c == '0') {
-            if (Py_Py3kWarningFlag) {
-                if (PyErr_WarnExplicit(PyExc_Py3xWarning,
-                                    "octal literals are not supported in 3.x;\n" 
-                                    "drop the leading 0",
-                                    tok->filename, tok->lineno, NULL, NULL)) {
-                    return NULL;
-                }
-            }
             /* Hex, octal or binary -- maybe. */
             c = tok_nextc(tok);
             if (c == '.')
@@ -1449,6 +1441,15 @@ tok_get(register struct tok_state *tok, char **p_start, char **p_end)
             if (c == 'j' || c == 'J')
                 goto imaginary;
 #endif
+            if (c != 'o' || c != 'O') {
+                char buf[100];
+                if (Py_Py3kWarningFlag) {
+                    if (PyErr_WarnExplicit_WithFix(PyExc_Py3xWarning, "using just a '0' prefix for octal literals is not supported in 3.x", 
+                                                   "use the '0o' prefix for octal integers, if you intended the integer to be decimal", tok->filename, tok->lineno, NULL, NULL)) {
+                        return NULL;
+                    }
+                }
+            }
             if (c == 'x' || c == 'X') {
 
                 /* Hex */

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -246,6 +246,55 @@ update_registry(PyObject *registry, PyObject *text, PyObject *category,
 }
 
 static void
+show_warning_with_fix(PyObject *filename, int lineno, PyObject *text, PyObject *fix_txt, PyObject
+                *category, PyObject *sourceline)
+{
+    PyObject *f_stderr;
+    PyObject *name;
+    char lineno_str[128];
+
+    PyOS_snprintf(lineno_str, sizeof(lineno_str), ":%d: ", lineno);
+
+    name = PyObject_GetAttrString(category, "__name__");
+    if (name == NULL)  /* XXX Can an object lack a '__name__' attribute? */
+        return;
+
+    f_stderr = PySys_GetObject("stderr");
+    if (f_stderr == NULL) {
+        fprintf(stderr, "lost sys.stderr\n");
+        Py_DECREF(name);
+        return;
+    }
+
+    /* Print "filename:lineno: category: text\n" */
+    PyFile_WriteObject(filename, f_stderr, Py_PRINT_RAW);
+    PyFile_WriteString(lineno_str, f_stderr);
+    PyFile_WriteObject(name, f_stderr, Py_PRINT_RAW);
+    PyFile_WriteString(": ", f_stderr);
+    PyFile_WriteObject(text, f_stderr, Py_PRINT_RAW);
+    PyFile_WriteString(": ", f_stderr);
+    PyFile_WriteObject(fix_txt, f_stderr, Py_PRINT_RAW);
+    PyFile_WriteString(".", f_stderr);
+    PyFile_WriteString("\n", f_stderr);
+    Py_XDECREF(name);
+
+    /* Print "  source_line\n" */
+    if (sourceline) {
+        char *source_line_str = PyString_AS_STRING(sourceline);
+        while (*source_line_str == ' ' || *source_line_str == '\t' ||
+                *source_line_str == '\014')
+            source_line_str++;
+
+        PyFile_WriteString(source_line_str, f_stderr);
+        PyFile_WriteString("\n", f_stderr);
+    }
+    else
+        _Py_DisplaySourceLine(f_stderr, PyString_AS_STRING(filename),
+                              lineno, 2);
+    PyErr_Clear();
+}
+
+static void
 show_warning(PyObject *filename, int lineno, PyObject *text, PyObject
                 *category, PyObject *sourceline)
 {
@@ -440,6 +489,167 @@ warn_explicit(PyObject *category, PyObject *message,
     Py_XDECREF(lineno_obj);
     Py_DECREF(module);
     Py_XDECREF(message);
+    return result;  /* Py_None or NULL. */
+}
+
+static PyObject *
+warn_explicit_with_fix(PyObject *category, PyObject *message,
+              PyObject *fix, PyObject *filename, int lineno,
+              PyObject *module, PyObject *registry, PyObject *sourceline)
+{
+    PyObject *key = NULL, *fix_txt = NULL, *text = NULL, *result = NULL, *lineno_obj = NULL;
+    PyObject *item = Py_None;
+    const char *action;
+    int rc, rc_fix;
+
+    if (registry && !PyDict_Check(registry) && (registry != Py_None)) {
+        PyErr_SetString(PyExc_TypeError, "'registry' must be a dict or None");
+        return NULL;
+    }
+
+    if (module == NULL) {
+        module = normalize_module(filename);
+        if (module == NULL)
+            return NULL;
+    }
+    else
+        Py_INCREF(module);
+
+    Py_INCREF(message);
+    Py_INCREF(fix);
+    rc = PyObject_IsInstance(message, PyExc_Warning);
+    rc_fix = PyObject_IsInstance(fix, PyExc_Warning);
+    if (rc == -1 || rc_fix == -1) {
+        goto cleanup;
+    }
+    if (rc == 1) {
+        text = PyObject_Str(message);
+        if (text == NULL)
+            goto cleanup;
+        category = (PyObject*)message->ob_type;
+    }
+    else {
+        text = message;
+        message = PyObject_CallFunction(category, "O", message);
+        if (message == NULL)
+            goto cleanup;
+    }
+
+    if (rc_fix == 1) {
+        fix_txt = PyObject_Str(fix);
+        if (fix_txt == NULL)
+            goto cleanup;
+        category = (PyObject*)fix->ob_type;
+    }
+    else {
+        fix_txt = fix;
+        fix = PyObject_CallFunction(category, "O", fix);
+        if (fix == NULL)
+            goto cleanup;
+    }
+
+    lineno_obj = PyInt_FromLong(lineno);
+    if (lineno_obj == NULL)
+        goto cleanup;
+
+    key = PyTuple_Pack(4, text, fix_txt, category, lineno_obj);
+    if (key == NULL)
+        goto cleanup;
+
+    if ((registry != NULL) && (registry != Py_None)) {
+        rc = already_warned(registry, key, 0);
+        if (rc == -1)
+            goto cleanup;
+        else if (rc == 1)
+            goto return_none;
+    }
+
+    action = get_filter(category, text, lineno, module, &item);
+    if (action == NULL)
+        goto cleanup;
+
+    if (strcmp(action, "error") == 0) {
+        PyErr_SetObject(category, message);
+        goto cleanup;
+    }
+
+    rc = 0;
+    if (strcmp(action, "always") != 0) {
+        if (registry != NULL && registry != Py_None &&
+                PyDict_SetItem(registry, key, Py_True) < 0)
+            goto cleanup;
+        else if (strcmp(action, "ignore") == 0)
+            goto return_none;
+        else if (strcmp(action, "once") == 0) {
+            if (registry == NULL || registry == Py_None) {
+                registry = get_once_registry();
+                if (registry == NULL)
+                    goto cleanup;
+            }
+            rc = update_registry(registry, text, category, 0);
+        }
+        else if (strcmp(action, "module") == 0) {
+            if (registry != NULL && registry != Py_None)
+                rc = update_registry(registry, text, category, 0);
+        }
+        else if (strcmp(action, "default") != 0) {
+            PyObject *to_str = PyObject_Str(item);
+            const char *err_str = "???";
+
+            if (to_str != NULL)
+                err_str = PyString_AS_STRING(to_str);
+            PyErr_Format(PyExc_RuntimeError,
+                        "Unrecognized action (%s) in warnings.filters:\n %s",
+                        action, err_str);
+            Py_XDECREF(to_str);
+            goto cleanup;
+        }
+    }
+
+    if (rc == 1)
+        goto return_none;
+    if (rc == 0) {
+        PyObject *show_fxn = get_warnings_attr("showwarningwithfix");
+        if (show_fxn == NULL) {
+            if (PyErr_Occurred())
+                goto cleanup;
+            show_warning_with_fix(filename, lineno, text, fix_txt, category, sourceline);
+        }
+        else {
+              PyObject *res;
+
+              if (!PyMethod_Check(show_fxn) && !PyFunction_Check(show_fxn)) {
+                  PyErr_SetString(PyExc_TypeError,
+                                  "warnings.showwarningwithfix() must be set to a "
+                                  "function or method");
+                  Py_DECREF(show_fxn);
+                  goto cleanup;
+              }
+
+              res = PyObject_CallFunctionObjArgs(show_fxn, message, fix, category,
+                                                  filename, lineno_obj,
+                                                  NULL);
+              Py_DECREF(show_fxn);
+              Py_XDECREF(res);
+              if (res == NULL)
+                  goto cleanup;
+        }
+    }
+    else
+        goto cleanup;
+
+ return_none:
+    result = Py_None;
+    Py_INCREF(result);
+
+ cleanup:
+    Py_XDECREF(key);
+    Py_XDECREF(text);
+    Py_XDECREF(fix_txt);
+    Py_XDECREF(lineno_obj);
+    Py_DECREF(module);
+    Py_XDECREF(message);
+    Py_XDECREF(fix);
     return result;  /* Py_None or NULL. */
 }
 
@@ -710,6 +920,93 @@ warnings_warn_explicit(PyObject *self, PyObject *args, PyObject *kwds)
                                 registry, NULL);
 }
 
+static PyObject *
+warnings_warn_explicit_with_fix(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    static char *kwd_list[] = {"message", "fix", "category", "filename", "lineno",
+                                "module", "registry", "module_globals", 0};
+    PyObject *message;
+    PyObject *fix;
+    PyObject *category;
+    PyObject *filename;
+    int lineno;
+    PyObject *module = NULL;
+    PyObject *registry = NULL;
+    PyObject *module_globals = NULL;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OOOOi|OOO:warn_explicit_with_fix",
+                kwd_list, &message, &fix, &category, &filename, &lineno, &module,
+                &registry, &module_globals))
+        return NULL;
+
+    if (module_globals) {
+        static PyObject *get_source_name = NULL;
+        static PyObject *splitlines_name = NULL;
+        PyObject *loader;
+        PyObject *module_name;
+        PyObject *source;
+        PyObject *source_list;
+        PyObject *source_line;
+        PyObject *returned;
+
+        if (get_source_name == NULL) {
+            get_source_name = PyString_InternFromString("get_source");
+            if (!get_source_name)
+                return NULL;
+        }
+        if (splitlines_name == NULL) {
+            splitlines_name = PyString_InternFromString("splitlines");
+            if (!splitlines_name)
+                return NULL;
+        }
+
+        /* Check/get the requisite pieces needed for the loader. */
+        loader = PyDict_GetItemString(module_globals, "__loader__");
+        module_name = PyDict_GetItemString(module_globals, "__name__");
+
+        if (loader == NULL || module_name == NULL)
+            goto standard_call;
+
+        /* Make sure the loader implements the optional get_source() method. */
+        if (!PyObject_HasAttrString(loader, "get_source"))
+                goto standard_call;
+        /* Call get_source() to get the source code. */
+        source = PyObject_CallMethodObjArgs(loader, get_source_name,
+                                                module_name, NULL);
+        if (!source)
+            return NULL;
+        else if (source == Py_None) {
+            Py_DECREF(Py_None);
+            goto standard_call;
+        }
+
+        /* Split the source into lines. */
+        source_list = PyObject_CallMethodObjArgs((PyObject *)&PyString_Type,
+                                                 splitlines_name, source,
+                                                 NULL);
+        Py_DECREF(source);
+        if (!source_list)
+            return NULL;
+
+        /* Get the source line. */
+        source_line = PyList_GetItem(source_list, lineno-1);
+        if (!source_line) {
+            Py_DECREF(source_list);
+            return NULL;
+        }
+
+        /* Handle the warning. */
+        returned = warn_explicit_with_fix(category, message, fix, filename, lineno, module,
+                            registry, source_line);
+        Py_DECREF(source_list);
+        return returned;
+    }
+
+ standard_call:
+    return warn_explicit_with_fix(category, message, fix, filename, lineno, module,
+                                registry, NULL);
+}
+
 
 /* Function to issue a warning message; may raise an exception. */
 int
@@ -779,6 +1076,44 @@ PyErr_WarnExplicit(PyObject *category, const char *text,
     return ret;
 }
 
+/* Warning with explicit origin and a fix*/
+int
+PyErr_WarnExplicit_WithFix(PyObject *category, const char *text,
+                   const char *fix_str, const char *filename_str, int lineno,
+                   const char *module_str, PyObject *registry)
+{
+    PyObject *res;
+    PyObject *message = PyString_FromString(text);
+    PyObject *fix = PyString_FromString(fix_str);
+    PyObject *filename = PyString_FromString(filename_str);
+    PyObject *module = NULL;
+    int ret = -1;
+
+    if (message == NULL || filename == NULL || fix == NULL)
+        goto exit;
+    if (module_str != NULL) {
+        module = PyString_FromString(module_str);
+            if (module == NULL)
+                goto exit;
+    }
+
+    if (category == NULL)
+        category = PyExc_RuntimeWarning;
+    res = warn_explicit_with_fix(category, message, fix, filename, lineno, module, registry,
+                        NULL);
+    if (res == NULL)
+        goto exit;
+    Py_DECREF(res);
+    ret = 0;
+
+ exit:
+    Py_XDECREF(message);
+    Py_XDECREF(fix);
+    Py_XDECREF(module);
+    Py_XDECREF(filename);
+    return ret;
+}
+
 
 PyDoc_STRVAR(warn_doc,
 "Issue a warning, or maybe ignore it or raise an exception.");
@@ -786,11 +1121,17 @@ PyDoc_STRVAR(warn_doc,
 PyDoc_STRVAR(warn_explicit_doc,
 "Low-level inferface to warnings functionality.");
 
+PyDoc_STRVAR(warn_explicit_with_fix_doc,
+"Low-level inferface to warnings functionality with a 'fix' argument.");
+
 static PyMethodDef warnings_functions[] = {
     {"warn", (PyCFunction)warnings_warn, METH_VARARGS | METH_KEYWORDS,
         warn_doc},
     {"warn_explicit", (PyCFunction)warnings_warn_explicit,
         METH_VARARGS | METH_KEYWORDS, warn_explicit_doc},
+    {"warn_explicit_with_fix", (PyCFunction)warnings_warn_explicit_with_fix,
+        METH_VARARGS | METH_KEYWORDS, warn_explicit_with_fix_doc},
+
     /* XXX(brett.cannon): add showwarning? */
     /* XXX(brett.cannon): Reasonable to add formatwarning? */
     {NULL, NULL}	        /* sentinel */

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -131,9 +131,9 @@ ast_warn(struct compiling *c, const node *n, char *msg)
 }
 
 static int
-ast_3x_warn(struct compiling *c, const node *n, char *msg)
+ast_3x_warn(struct compiling *c, const node *n, char *msg, char *fix)
 {
-    if (PyErr_WarnExplicit(PyExc_Py3xWarning, msg, c->c_filename, LINENO(n),
+    if (PyErr_WarnExplicit_WithFix(PyExc_Py3xWarning, msg, fix, c->c_filename, LINENO(n),
                            NULL, NULL) < 0) {
         /* if -Werr, change it to a SyntaxError */
         if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_Py3xWarning))
@@ -3355,8 +3355,8 @@ parsenumber(struct compiling *c, const node *n, const char *s)
 #endif
         if (*end == 'l' || *end == 'L') {
                 if (Py_Py3kWarningFlag &&
-                    !ast_3x_warn(c, n, "the L suffix is not supported in 3.x; simply drop the suffix, \n" 
-                                 "or accept the auto fixer modifications")) {
+                    !ast_3x_warn(c, n, "the L suffix is not supported in 3.x", 
+                                 "drop the suffix")) {
                         return NULL;
                 }
                 return PyLong_FromString((char *)s, (char **)0, 0);


### PR DESCRIPTION
Most of the warnings are covered on the list sort method.

I added the missing warnings for the `cmp` and `__cmp__` method.

This PR builds on #3 hence the other changes are showing because I had to use the new exception.