### PR TITLE
Add warnings for the print statement

### DIFF
--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -458,6 +458,23 @@ hello world
         check_syntax_error(self, 'print ,')
         check_syntax_error(self, 'print >> x,')
 
+    def test_print_py3k_warnings(self):
+        if sys.py3kwarning:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.filterwarnings('always', category=Py3xWarning)
+                print 1, 2, 3
+                print 1, 2, 3,
+                print
+
+                # 'print' '>>' test ','
+                print >> sys.stdout, 1, 2, 3
+                print >> sys.stdout, 1, 2, 3,
+                print >> sys.stdout
+                for warning in w:
+                    self.assertTrue(Py3xWarning is w.category)
+                    self.assertEqual(str(w.message), "print must be called as a function, not a statement in 3.x", 
+                                     "You can fix this now by using parentheses for arguments to 'print'")
+
     def test_del_stmt(self):
         # 'del' exprlist
         abc = [1,2,3]

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -2294,6 +2294,12 @@ ast_for_print_stmt(struct compiling *c, const node *n)
     int i, j, values_count, start = 1;
 
     REQ(n, print_stmt);
+    if (Py_Py3kWarningFlag && TYPE(CHILD(n, 1)) != LPAR) {
+        if (!ast_3x_warn(c, n,
+            "print must be called as a function, not a statement in 3.x", 
+            "You can fix this now by using parentheses for arguments to 'print'"))
+            return NULL;              
+    }
     if (NCH(n) >= 2 && TYPE(CHILD(n, 1)) == RIGHTSHIFT) {
         dest = ast_for_expr(c, CHILD(n, 2));
         if (!dest)


### PR DESCRIPTION
A Py3k syntax warning has been added for the print statement.

This PR should replace #2 