### PR TITLE
Add warnings for sorting and comparison

### DIFF
--- a/Include/warnings.h
+++ b/Include/warnings.h
@@ -7,6 +7,7 @@ extern "C" {
 PyAPI_FUNC(void) _PyWarnings_Init(void);
 
 PyAPI_FUNC(int) PyErr_WarnEx(PyObject *, const char *, Py_ssize_t);
+PyAPI_FUNC(int) PyErr_WarnEx_WithFix(PyObject *, const char *, const char *, Py_ssize_t);
 PyAPI_FUNC(int) PyErr_WarnExplicit(PyObject *, const char *, const char *, int,
                                     const char *, PyObject *);
 PyAPI_FUNC(int) PyErr_WarnExplicit_WithFix(PyObject *, const char *, const char *, const char *, int,

--- a/Lib/test/test_sort.py
+++ b/Lib/test/test_sort.py
@@ -278,6 +278,11 @@ def test_main(verbose=None):
             ("the cmp argument is not supported", DeprecationWarning)):
         test_support.run_unittest(*test_classes)
 
+    with test_support.check_py3k_warnings(
+            ("the cmp method is not supported in 3.x"
+             "implement the function to a utility library", Py3xWarning)):
+        test_support.run_unittest(*test_classes)
+
         # verify reference counting
         if verbose and hasattr(sys, "gettotalrefcount"):
             import gc

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -860,6 +860,13 @@ PyObject_Compare(PyObject *v, PyObject *w)
 {
     int result;
 
+    if (Py_Py3kWarningFlag &&
+        PyErr_WarnEx_WithFix(PyExc_Py3xWarning, "the cmp method is not supported in 3.x",
+        "you can either provide your own alternative or use a third party library with a "
+         "backwards compatible fix", 1) < 0) {
+        return 0;
+    }
+
     if (v == NULL || w == NULL) {
         PyErr_BadInternalCall();
         return -1;


### PR DESCRIPTION
Most of the warnings are covered on the list sort method.

I added the missing warnings for the `cmp` and `__cmp__` method.

This replaces #4 