### PR TITLE
Warn for using built-in open

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -333,6 +333,11 @@ is a separate error indicator for each thread.
 
    .. versionadded:: 2.6
 
+.. c:function:: int PyErr_WarnPy3k_WithFix(char *message, char *fix, int stacklevel)
+
+   Issue a :exc:`DeprecationWarning` with the given *message* and *stacklevel*
+   if the :c:data:`Py_Py3kWarningFlag` flag is enabled.
+
 
 .. c:function:: int PyErr_CheckSignals()
 

--- a/Lib/test/test_py3kwarn.py
+++ b/Lib/test/test_py3kwarn.py
@@ -247,6 +247,20 @@ class TestPy3KWarnings(unittest.TestCase):
             with check_py3k_warnings() as w:
                 self.assertWarning(f.xreadlines(), w, expected)
 
+    def test_file_open(self):
+        expected = ("The builtin 'file()'/'open()' function is not supported in 3.x, "
+                       "use the 'io.open()' function instead with the encoding keyword argument")
+        with open(__file__) as f:
+            with check_py3k_warnings() as w:
+                self.assertWarning(f.read(), w, expected)
+
+    def test_file(self):
+        expected = ("The builtin 'file()'/'open()' function is not supported in 3.x, "
+                    "use the 'io.open()' function instead with the encoding keyword argument")
+        with file(__file__) as f:
+            with check_py3k_warnings() as w:
+                self.assertWarning(f.read(), w, expected)
+
     def test_hash_inheritance(self):
         with check_py3k_warnings() as w:
             # With object as the base class

--- a/Objects/fileobject.c
+++ b/Objects/fileobject.c
@@ -323,6 +323,10 @@ _PyFile_SanitizeMode(char *mode)
 static PyObject *
 open_the_file(PyFileObject *f, char *name, char *mode)
 {
+    if (PyErr_WarnPy3k_WithFix("The builtin 'file()'/'open()' function is not supported in 3.x, ",
+                       "use the 'io.open()' function instead with the encoding keyword argument", 1) < 0)
+        return NULL;
+
     char *newmode;
     assert(f != NULL);
     assert(PyFile_Check(f));

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1507,6 +1507,7 @@ builtin_open(PyObject *self, PyObject *args, PyObject *kwds)
     return PyObject_Call((PyObject*)&PyFile_Type, args, kwds);
 }
 
+
 PyDoc_STRVAR(open_doc,
 "open(name[, mode[, buffering]]) -> file object\n\
 \n\


### PR DESCRIPTION
Warn for file open. I was struggling to support the generic case assuming io.open doesnt exist.
A warning is simpler to do assuming support for >=2.6. I added notes in the Google doc for this.