### PR TITLE
Warn for raise with three compnents

### DIFF
--- a/Lib/test/test_py3kwarn.py
+++ b/Lib/test/test_py3kwarn.py
@@ -369,6 +369,13 @@ class TestPy3KWarnings(unittest.TestCase):
         with check_py3k_warnings((expected, SyntaxWarning)):
             exec "b'\xbd'"
 
+    def test_raise_three_components(self):
+        expected = """the  raise clause with three components is not supported in 3.x; \
+                    use 'raise' with a single object"""
+        with check_py3k_warnings((expected, SyntaxWarning)):
+            excType, excValue, excTraceback = sys.exc_info()
+            raise excType, excValue, excTraceback
+
 
 class TestStdlibRemovals(unittest.TestCase):
 

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -2459,6 +2459,12 @@ ast_for_flow_stmt(struct compiling *c, const node *n)
             else if (NCH(ch) == 6) {
                 expr_ty expr1, expr2, expr3;
 
+                if (Py_Py3kWarningFlag &&
+                    !ast_3x_warn(c, n, "the  raise clause with three components is not supported in 3.x", 
+                                 "use 'raise' with a single object")) {
+                        return NULL;
+                }
+
                 expr1 = ast_for_expr(c, CHILD(ch, 1));
                 if (!expr1)
                     return NULL;


### PR DESCRIPTION
This makes sense at the AST hence isolated from the [other exception PR](https://github.com/softdevteam/pygrate2/pull/12)