### PR TITLE
Warn for the threading and thread modules

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1,7 +1,7 @@
 # Very rudimentary test of threading module
 
 import test.test_support
-from test.test_support import verbose, cpython_only
+from test.test_support import verbose, cpython_only, check_py3k_warnings
 from test.script_helper import assert_python_ok
 
 import random
@@ -479,6 +479,23 @@ class ThreadTests(BaseTestCase):
             for t in threads:
                 t.join()
             self.assertRaises(ValueError, bs.release)
+
+    def test_py3k_thread_module(sellf):
+        expected = "In 3.x, the thread module is removed: use the threading module instead"
+        with check_py3k_warnings() as w:
+            from thread import get_ident
+    
+    def test_threading_module_method_rename(self):
+        import threading
+        expected = "_get_ident is removed in 3.x: use get_ident instead"
+        with check_py3k_warnings() as w:
+            _get_indent()
+        expected = "_start_new_thread is removed in 3.x: use start_new_thread instead"
+        with check_py3k_warnings() as w:
+            _start_new_thread()
+        expected = "_allocate_lock is removed in 3.x: use allocate_lock instead"
+        with check_py3k_warnings() as w:
+            _allocate_lock()
 
 class ThreadJoinOnShutdown(BaseTestCase):
 

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -32,9 +32,20 @@ __all__ = ['activeCount', 'active_count', 'Condition', 'currentThread',
            'Lock', 'RLock', 'Semaphore', 'BoundedSemaphore', 'Thread',
            'Timer', 'setprofile', 'settrace', 'local', 'stack_size']
 
-_start_new_thread = thread.start_new_thread
-_allocate_lock = thread.allocate_lock
-_get_ident = thread.get_ident
+def _get_ident():
+    warnings.warnpy3k_with_fix("_get_ident is removed in 3.x", "use get_ident instead",
+                      stacklevel=2)
+    thread.get_ident
+
+def _start_new_thread():
+    warnings.warnpy3k_with_fix("_start_new_thread is removed in 3.x", "use start_new_thread instead",
+                      stacklevel=2)
+    thread.start_new_thread
+
+def _allocate_lock():
+    warnings.warnpy3k_with_fix("_allocate_lock is removed in 3.x", "use allocate_lock instead",
+                      stacklevel=2)
+    thread.allocate_lock
 ThreadError = thread.error
 del thread
 

--- a/Modules/threadmodule.c
+++ b/Modules/threadmodule.c
@@ -904,6 +904,10 @@ initthread(void)
 {
     PyObject *m, *d;
 
+    if (PyErr_WarnPy3k_WithFix("In 3.x, the thread module is removed", 
+                                "use the threading module instead", 1))
+        return;
+
     /* Initialize types: */
     if (PyType_Ready(&localdummytype) < 0)
         return;


### PR DESCRIPTION
Dont merge until #13  and  #14 are merged, some helper code cuts across.

Threading module Notes

Python 2:

```
>>> from thread import get_ident
>>> from threading import get_ident
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name get_ident
>>> import threading
>>> from threading import _get_ident
>>>
```

Python 3:

```
>>> from threading import get_ident
>>> from thread import get_ident
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'thread'
>
```

**Note:**

There is no neutral way of porting