### PR TITLE
Warn for specific thread module methods

### DIFF
--- a/Lib/test/test_thread.py
+++ b/Lib/test/test_thread.py
@@ -2,6 +2,7 @@ import os
 import unittest
 import random
 from test import support
+from test.test_support import check_py3k_warnings
 thread = support.import_module('thread')
 import time
 import sys
@@ -156,6 +157,51 @@ class ThreadRunningTests(BasicThreadTest):
                 thread.start_new_thread(task, ())
                 started.acquire()
         self.assertIn("Traceback", stderr.getvalue())
+
+    def test_py3k_thread_module(self):
+        expected = "In 3.x, the thread module is removed: use the threading module instead"
+        with check_py3k_warnings() as w:
+            import thread
+
+    def test_py3k_thread_module_get_ident(self):
+        expected = "thread.get_ident is removed in 3.x: use the threading.get_ident instead"
+        with check_py3k_warnings() as w:
+            thread.get_ident()
+
+    def test_py3k_thread_module_start_new_thread(self):
+        expected = "thread.start_new_thread is removed in 3.x: use the threading._start_new_thread instead"
+        with check_py3k_warnings() as w:
+            def f():
+                ident.append(threading.currentThread().ident)
+                done.set()
+            thread.start_new_thread((f), ())
+
+    def test_py3k_thread_module_allocate(self):
+        expected = "thread.allocate_lock is removed in 3.x: use the threading._allocate_lock instead"
+        with check_py3k_warnings() as w:
+            thread.allocate_lock()
+
+    def test_py3k_thread_module_exit_thread(self):
+        expected = "thread.exit is removed in 3.x: no equivalent method exists, raising SystemExit will exit a thread"
+        with check_py3k_warnings() as w:
+            with self.assertRaises(SystemExit):
+                thread.exit_thread()
+
+    def test_py3k_thread_module_interrupt_main(self):
+        expected = "thread.interrupt_main is removed in 3.x: no equivalent method exists, raising KeyboardInterrupt will interruot the main thread"
+        with check_py3k_warnings() as w:
+            with self.assertRaises(KeyboardInterrupt):
+                thread.interrupt_main()
+
+    def test_py3k_thread_module_count(self):
+        expected = "thread._count is removed in 3.x: use the threading.count instead"
+        with check_py3k_warnings() as w:
+            thread._count()
+
+    def test_py3k_thread_module_stack_size(self):
+        expected = "thread.stack_size is removed in 3.x: use threading.stack_size instead"
+        with check_py3k_warnings() as w:
+            thread.stack_size()
 
 
 class Barrier:

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1,7 +1,7 @@
 # Very rudimentary test of threading module
 
 import test.test_support
-from test.test_support import verbose, cpython_only
+from test.test_support import verbose, cpython_only, check_py3k_warnings
 from test.script_helper import assert_python_ok
 
 import random
@@ -479,6 +479,21 @@ class ThreadTests(BaseTestCase):
             for t in threads:
                 t.join()
             self.assertRaises(ValueError, bs.release)
+
+    def test_threading_module_method_rename(self):
+        import threading
+        expected = "_get_ident is removed in 3.x: use get_ident instead"
+        with check_py3k_warnings() as w:
+           threading. _get_ident()
+        expected = "_start_new_thread is removed in 3.x: use start_new_thread instead"
+        with check_py3k_warnings() as w:
+            def f():
+                ident.append(threading.currentThread().ident)
+                done.set()
+            threading._start_new_thread((f), ())
+        expected = "_allocate_lock is removed in 3.x: use allocate_lock instead"
+        with check_py3k_warnings() as w:
+           threading._allocate_lock()
 
 class ThreadJoinOnShutdown(BaseTestCase):
 

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -32,25 +32,24 @@ __all__ = ['activeCount', 'active_count', 'Condition', 'currentThread',
            'Lock', 'RLock', 'Semaphore', 'BoundedSemaphore', 'Thread',
            'Timer', 'setprofile', 'settrace', 'local', 'stack_size']
 
+def _get_ident():
+    warnings.warnpy3k_with_fix("_get_ident() is renamed in 3.x", "use get_ident() instead",
+                      stacklevel=2)
+    thread.get_ident
+
+def _start_new_thread():
+    warnings.warnpy3k_with_fix("_start_new_thread() is removed in 3.x", "use start_new_thread() instead",
+                      stacklevel=2)
+    thread.start_new_thread
+
+def _allocate_lock():
+    warnings.warnpy3k_with_fix("_allocate_lock() is removed in 3.x", "use allocate_lock instead",
+                      stacklevel=2)
+    thread.allocate_lock
+
 _start_new_thread = thread.start_new_thread
 _allocate_lock = thread.allocate_lock
 _get_ident = thread.get_ident
-
-# def _get_ident():
-#     warnings.warnpy3k_with_fix("_get_ident() is renamed in 3.x", "use get_ident() instead",
-#                       stacklevel=2)
-#     thread.get_ident
-
-# def _start_new_thread():
-#     warnings.warnpy3k_with_fix("_start_new_thread() is removed in 3.x", "use start_new_thread() instead",
-#                       stacklevel=2)
-#     thread.start_new_thread
-
-# def _allocate_lock():
-#     warnings.warnpy3k_with_fix("_allocate_lock() is removed in 3.x", "use allocate_lock instead",
-#                       stacklevel=2)
-#     thread.allocate_lock
-
 ThreadError = thread.error
 del thread
 

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -35,6 +35,22 @@ __all__ = ['activeCount', 'active_count', 'Condition', 'currentThread',
 _start_new_thread = thread.start_new_thread
 _allocate_lock = thread.allocate_lock
 _get_ident = thread.get_ident
+
+# def _get_ident():
+#     warnings.warnpy3k_with_fix("_get_ident() is renamed in 3.x", "use get_ident() instead",
+#                       stacklevel=2)
+#     thread.get_ident
+
+# def _start_new_thread():
+#     warnings.warnpy3k_with_fix("_start_new_thread() is removed in 3.x", "use start_new_thread() instead",
+#                       stacklevel=2)
+#     thread.start_new_thread
+
+# def _allocate_lock():
+#     warnings.warnpy3k_with_fix("_allocate_lock() is removed in 3.x", "use allocate_lock instead",
+#                       stacklevel=2)
+#     thread.allocate_lock
+
 ThreadError = thread.error
 del thread
 

--- a/Modules/threadmodule.c
+++ b/Modules/threadmodule.c
@@ -657,6 +657,10 @@ thread_PyThread_start_new_thread(PyObject *self, PyObject *fargs)
     struct bootstate *boot;
     long ident;
 
+    if (PyErr_WarnPy3k_WithFix("thread.start_new_thread is removed in 3.x", 
+                                "use the threading._start_new_thread instead", 1))
+        return NULL;
+
     if (!PyArg_UnpackTuple(fargs, "start_new_thread", 2, 3,
                            &func, &args, &keyw))
         return NULL;
@@ -718,6 +722,10 @@ printed unless the exception is SystemExit.\n");
 static PyObject *
 thread_PyThread_exit_thread(PyObject *self)
 {
+    if (PyErr_WarnPy3k_WithFix("thread.exit is removed in 3.x", 
+                                "no equivalent method exists, raising SystemExit will exit a thread", 1))
+        return NULL;
+
     PyErr_SetNone(PyExc_SystemExit);
     return NULL;
 }
@@ -732,6 +740,10 @@ thread to exit silently unless the exception is caught.");
 static PyObject *
 thread_PyThread_interrupt_main(PyObject * self)
 {
+    if (PyErr_WarnPy3k_WithFix("thread.interrupt_main is removed in 3.x", 
+                                "no equivalent method exists, raising KeyboardInterrupt will interruot the main thread", 1))
+        return NULL;
+
     PyErr_SetInterrupt();
     Py_INCREF(Py_None);
     return Py_None;
@@ -749,6 +761,10 @@ static lockobject *newlockobject(void);
 static PyObject *
 thread_PyThread_allocate_lock(PyObject *self)
 {
+    if (PyErr_WarnPy3k_WithFix("thread.allocate_lock is removed in 3.x", 
+                                "use the threading._allocate_lock instead", 1))
+        return NULL;
+
     return (PyObject *) newlockobject();
 }
 
@@ -762,6 +778,10 @@ static PyObject *
 thread_get_ident(PyObject *self)
 {
     long ident;
+    if (PyErr_WarnPy3k_WithFix("thread.get_ident is removed in 3.x", 
+                                "use the threading.get_ident instead", 1))
+        return NULL;
+
     ident = PyThread_get_thread_ident();
     if (ident == -1) {
         PyErr_SetString(ThreadError, "no current thread ident");
@@ -784,6 +804,10 @@ A thread's identity may be reused for another thread after it exits.");
 static PyObject *
 thread__count(PyObject *self)
 {
+    if (PyErr_WarnPy3k_WithFix("thread.count is removed in 3.x", 
+                                "use the threading._count instead", 1))
+        return NULL;
+
     return PyInt_FromLong(nb_threads);
 }
 
@@ -805,6 +829,10 @@ thread_stack_size(PyObject *self, PyObject *args)
     size_t old_size;
     Py_ssize_t new_size = 0;
     int rc;
+
+     if (PyErr_WarnPy3k_WithFix("thread.stack_size is removed in 3.x", 
+                                "use the threading.stack_size instead", 1))
+        return NULL;
 
     if (!PyArg_ParseTuple(args, "|n:stack_size", &new_size))
         return NULL;
@@ -903,6 +931,10 @@ PyMODINIT_FUNC
 initthread(void)
 {
     PyObject *m, *d;
+
+    if (PyErr_WarnPy3k_WithFix("In 3.x, the thread module is removed", 
+                                "use the threading module instead", 1))
+        return;
 
     /* Initialize types: */
     if (PyType_Ready(&localdummytype) < 0)


### PR DESCRIPTION
Dont merge until #13  and  #14 are merged, some helper code cuts across.

This replaces #15 

Threading module Notes

Python 2:

```
>>> from thread import get_ident
>>> from threading import get_ident
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name get_ident
>>> import threading
>>> from threading import _get_ident
>>>
```

Python 3:

```
>>> from threading import get_ident
>>> from thread import get_ident
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'thread'
>
```

**Note:**

There is no neutral way of porting