### PR TITLE
Warn for encode and decode in base64

### DIFF
--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -9,6 +9,7 @@ import re
 import struct
 import string
 import binascii
+from warnings import warnpy3k_with_fix
 
 
 __all__ = [
@@ -28,7 +29,6 @@ __all__ = [
 
 _translation = [chr(_x) for _x in range(256)]
 EMPTYSTRING = ''
-
 
 def _translate(s, altchars):
     translation = _translation[:]
@@ -316,6 +316,8 @@ def decode(input, output):
 
 def encodestring(s):
     """Encode a string into multiple lines of base-64 data."""
+    warnpy3k_with_fix("base64.encodestring is not supported in 3.x", 
+                      "use base64.encodebytes instead", stacklevel=2)
     pieces = []
     for i in range(0, len(s), MAXBINSIZE):
         chunk = s[i : i + MAXBINSIZE]
@@ -325,6 +327,8 @@ def encodestring(s):
 
 def decodestring(s):
     """Decode a string."""
+    warnpy3k_with_fix("base64.decodestring is not supported in 3.x", 
+                      "use base64.decodebytes instead", stacklevel=2)
     return binascii.a2b_base64(s)
 
 

--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -1,6 +1,7 @@
 import unittest
 from test import test_support
 import base64
+import sys
 
 
 
@@ -21,6 +22,11 @@ class LegacyBase64TestCase(unittest.TestCase):
         # Non-bytes
         eq(base64.encodestring(bytearray('abc')), 'YWJj\n')
 
+        if sys.py3kwarning:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.filterwarnings('always', category=Py3xWarning)
+                base64.encodestring("")
+
     def test_decodestring(self):
         eq = self.assertEqual
         eq(base64.decodestring("d3d3LnB5dGhvbi5vcmc=\n"), "www.python.org")
@@ -36,6 +42,11 @@ class LegacyBase64TestCase(unittest.TestCase):
         eq(base64.decodestring(''), '')
         # Non-bytes
         eq(base64.decodestring(bytearray("YWJj\n")), "abc")
+
+        if sys.py3kwarning:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.filterwarnings('always', category=Py3xWarning)
+                base64.decodestring('')
 
     def test_encode(self):
         eq = self.assertEqual


### PR DESCRIPTION
Add warnings for the base module.

**Notes:**

```
py2.x

>>> import base64
>>> from base64 import decodestring
>>> 

py3.x:

>>> import base64
>>> from base64 import decodestring
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'decodestring' 
from 'base64' (/usr/local/Cellar/python@3.9/3.9.12_1/
Frameworks/Python.framework/Versions/3.9/lib/python3.9/
base64.py)
```