### PR TITLE
Warn for range and xrange

### DIFF
--- a/Lib/test/test_xrange.py
+++ b/Lib/test/test_xrange.py
@@ -1,6 +1,7 @@
 # Python test set -- built-in functions
 
 import test.test_support, unittest
+from test.test_support import check_py3k_warnings
 import sys
 import pickle
 import itertools
@@ -178,6 +179,11 @@ class XrangeTest(unittest.TestCase):
             r = xrange(*t)
             r_out = eval(repr(r))
             self.assert_xranges_equivalent(r, r_out)
+
+    def test_xrange_3k(self):
+        expected = "xrange() is not supported in 3.x: use range() instead"
+        with check_py3k_warnings((expected, DeprecationWarning)):
+            xrange(1, 10000)
 
     def test_range_iterators(self):
         # see issue 7298

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -68,6 +68,9 @@ range_new(PyTypeObject *type, PyObject *args, PyObject *kw)
     long ilow = 0, ihigh = 0, istep = 1;
     unsigned long n;
 
+    if (PyErr_WarnPy3k_WithFix("xrange() is not supported in 3.x", "use range() instead", 1) < 0)
+        return NULL;
+
     if (!_PyArg_NoKeywords("xrange()", kw))
         return NULL;
 


### PR DESCRIPTION
See notes:

```
Py2.x:

>>> x = xrange(1, 10000)
>>> a = range(1,10000)
>>> type(a)
<type 'list'>
>>> 

Py3.x:

>>> x = xrange(1, 10000)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'xrange' is not defined
>>> a = range(1,10000)
>>> type(a)
<class 'range'>
>>> 
```