### PR TITLE
warn for keys/items/values/range

### DIFF
--- a/Lib/test/test_py3kwarn.py
+++ b/Lib/test/test_py3kwarn.py
@@ -56,6 +56,17 @@ class TestPy3KWarnings(unittest.TestCase):
         # Something like def f((a, (b))): pass will raise the tuple
         # unpacking warning.
 
+    def test_warn_py3k_exceptions(self):
+        d = {}
+        for i in d.keys():
+            pass
+        for i in d.items():
+            pass
+        for i in d.values():
+            pass
+        for i in range(10):
+            pass
+        
     def test_forbidden_names(self):
         # So we don't screw up our globals
         def safe_exec(expr):
@@ -85,7 +96,21 @@ class TestPy3KWarnings(unittest.TestCase):
                 safe_exec("def f({0}=43): pass".format(keyword))
                 self.assertWarning(None, w, expected)
                 w.reset()
-
+        with check_py3k_warnings(('', SyntaxWarning)) as w:
+            keyword = "var"
+            x = {"one": 1}
+            safe_exec("{0} = x.keys()".format(keyword))
+            self.assertWarning(None, w, "dict.keys() returns a view in 3.x: convert the result to a list")
+            w.reset()
+            safe_exec("{0} = x.values()".format(keyword))
+            self.assertWarning(None, w, "x.values() returns a view in 3.x: convert the result to a list")
+            w.reset()
+            safe_exec("{0} = x.items()".format(keyword))
+            self.assertWarning(None, w, "dict.items() returns a view in 3.x: convert the result to a list")
+            w.reset()
+            safe_exec("{0} = range(10)".format(keyword))
+            self.assertWarning(None, w, "range() returns a view in 3.x: convert the result to a list")
+            w.reset()
 
     def test_type_inequality_comparisons(self):
         expected = 'type inequality comparisons not supported in 3.x'

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -262,6 +262,7 @@ class ProgramsTestCase(BaseTestCase):
         output = self.run_python(args)
         self.check_output(output)
 
+    @unittest.skipUnless(Py_DEBUG, 'need a debug build')
     def test_script_regrtest(self):
         # Lib/test/regrtest.py
         script = os.path.join(self.testdir, 'regrtest.py')
@@ -269,27 +270,32 @@ class ProgramsTestCase(BaseTestCase):
         args = self.python_args + [script] + self.regrtest_args + self.tests
         self.run_tests(args)
 
+    @unittest.skipUnless(Py_DEBUG, 'need a debug build')
     def test_module_test(self):
         # -m test
         args = self.python_args + ['-m', 'test'] + self.regrtest_args + self.tests
         self.run_tests(args)
 
+    @unittest.skipUnless(Py_DEBUG, 'need a debug build')
     def test_module_regrtest(self):
         # -m test.regrtest
         args = self.python_args + ['-m', 'test.regrtest'] + self.regrtest_args + self.tests
         self.run_tests(args)
 
+    @unittest.skipUnless(Py_DEBUG, 'need a debug build')
     def test_module_autotest(self):
         # -m test.autotest
         args = self.python_args + ['-m', 'test.autotest'] + self.regrtest_args + self.tests
         self.run_tests(args)
 
+    @unittest.skipUnless(Py_DEBUG, 'need a debug build')
     def test_module_from_test_autotest(self):
         # from test import autotest
         code = 'from test import autotest'
         args = self.python_args + ['-c', code] + self.regrtest_args + self.tests
         self.run_tests(args)
 
+    @unittest.skipUnless(Py_DEBUG, 'need a debug build')
     def test_script_autotest(self):
         # Lib/test/autotest.py
         script = os.path.join(self.testdir, 'autotest.py')

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -146,6 +146,8 @@ ast_3x_warn(struct compiling *c, const node *n, char *msg, char *fix)
 static int
 forbidden_check(struct compiling *c, const node *n, const char *x)
 {
+    Py_ssize_t len;
+
     if (!strcmp(x, "None"))
         return ast_error(n, "cannot assign to None");
     if (!strcmp(x, "__debug__"))
@@ -156,6 +158,19 @@ forbidden_check(struct compiling *c, const node *n, const char *x)
             return 0;
         if (!strcmp(x, "nonlocal") &&
             !ast_warn(c, n, "nonlocal is a keyword in 3.x"))
+            return 0;
+        len = PyString_Size(x);
+        if (strncmp(x + (len-7), ".keys()", 7) == 0 &&
+            !ast_3x_warn(c, n, "dict.keys() returns a view in 3.x", "convert the result to a list"))
+            return 0;
+        if (strncmp(x + (len-8), ".items()", 8) == 0 &&
+            !ast_3x_warn(c, n, "dict.items() returns a view in 3.x", "convert the result to a list"))
+            return 0;
+        if (strncmp(x + (len-8), ".values()", 8) == 0 &&
+            !ast_3x_warn(c, n, "dict.values() returns a view in 3.x", "convert the result to a list"))
+            return 0;
+        if (strncmp(x, "range(", 6) &&
+            !ast_3x_warn(c, n, "range() returns a view in 3.x", "convert the result to a list"))
             return 0;
     }
     return 1;


### PR DESCRIPTION
I think I was over-thinking the solution with flags at synbol table generation. I found a simple check at the AST that checks correctness of values assigned to wanr for things like "True" and other keywords and used this check to warn for these calls.

This warns for `keys/values/items/range`:

Accurate when the statement is in an assignment:

`x = range(20)`
` y = d.keys()`