### PR TITLE
warn for `iter.next()`

### DIFF
--- a/Lib/test/test_py3kwarn.py
+++ b/Lib/test/test_py3kwarn.py
@@ -206,6 +206,21 @@ class TestPy3KWarnings(unittest.TestCase):
                 w.reset()
                 self.assertWarning(setattr(f, attr, None), w, expected)
 
+    def test_listiter_next(self):
+        expected = "the attribute 'next' is not supported in 3.x: use '__next__' or create a 'next' alias"
+        lst = iter([1, 2, 3])
+        tup = iter((1, 2, 3))
+        dit = iter({"one": 1})
+        rge = iter(range(4))
+        st = iter({2, 3})
+
+        with check_py3k_warnings() as w:
+            self.assertWarning(lst.next(), w, expected)
+            self.assertWarning(tup.next(), w, expected)
+            self.assertWarning(dit.next(), w, expected)
+            self.assertWarning(rge.next(), w, expected)
+            self.assertWarning(rge.next(), w, expected)
+
     def test_sort_cmp_arg(self):
         expected = "the cmp argument is not supported in 3.x"
         lst = range(5)

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1292,6 +1292,10 @@ dequeiter_next(dequeiterobject *it)
 {
     PyObject *item;
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     if (it->deque->state != it->state) {
         it->counter = 0;
         PyErr_SetString(PyExc_RuntimeError,
@@ -1386,6 +1390,10 @@ deque_reviter(dequeobject *deque)
 static PyObject *
 dequereviter_next(dequeiterobject *it)
 {
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+        
     PyObject *item;
     if (it->counter == 0)
         return NULL;

--- a/Modules/_hotshot.c
+++ b/Modules/_hotshot.c
@@ -397,6 +397,10 @@ logreader_tp_iternext(LogReaderObject *self)
     unsigned char b0, b1;
 #endif
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     if (self->logfp == NULL) {
         PyErr_SetString(ProfilerError,
                         "cannot iterate over closed LogReader object");

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -1174,6 +1174,10 @@ buffered_iternext(buffered *self)
     PyObject *line;
     PyTypeObject *tp;
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     CHECK_INITIALIZED(self);
 
     tp = Py_TYPE(self);

--- a/Modules/_io/bytesio.c
+++ b/Modules/_io/bytesio.c
@@ -479,6 +479,10 @@ bytesio_iternext(bytesio *self)
     char *next;
     Py_ssize_t n;
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     CHECK_CLOSED(self);
 
     n = get_line(self, &next);

--- a/Modules/_io/stringio.c
+++ b/Modules/_io/stringio.c
@@ -317,6 +317,10 @@ stringio_iternext(stringio *self)
     CHECK_INITIALIZED(self);
     CHECK_CLOSED(self);
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     if (Py_TYPE(self) == &PyStringIO_Type) {
         /* Skip method call overhead for speed */
         line = _stringio_readline(self, -1);

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -2508,6 +2508,10 @@ textiowrapper_iternext(textio *self)
 
     CHECK_ATTACHED(self);
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     self->telling = 0;
     if (Py_TYPE(self) == &PyTextIOWrapper_Type) {
         /* Skip method call overhead for speed */

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -1,6 +1,6 @@
 /* cursor.c - the cursor type
  *
- * Copyright (C) 2004-2010 Gerhard Häring <gh@ghaering.de>
+ * Copyright (C) 2004-2010 Gerhard Hï¿½ring <gh@ghaering.de>
  *
  * This file is part of pysqlite.
  *
@@ -35,6 +35,10 @@ static pysqlite_StatementKind detect_statement_type(char* statement)
     char buf[20];
     char* src;
     char* dst;
+
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
 
     src = statement;
     /* skip over whitepace */

--- a/Modules/bz2module.c
+++ b/Modules/bz2module.c
@@ -1526,6 +1526,11 @@ BZ2File_iternext(BZ2FileObject *self)
 {
     PyStringObject* ret;
     ACQUIRE_LOCK(self);
+
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+        
     if (self->mode == MODE_CLOSED) {
         RELEASE_LOCK(self);
         PyErr_SetString(PyExc_ValueError,

--- a/Modules/cStringIO.c
+++ b/Modules/cStringIO.c
@@ -335,6 +335,11 @@ IO_iternext(Iobject *self)
 {
     PyObject *next;
     next = IO_readline((IOobject *)self, NULL);
+
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+        
     if (!next)
         return NULL;
     if (!PyString_GET_SIZE(next)) {

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -103,6 +103,10 @@ groupby_next(groupbyobject *gbo)
 {
     PyObject *r, *grouper;
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     /* skip to next iteration group */
     for (;;) {
         if (gbo->currkey == NULL)
@@ -234,6 +238,10 @@ _grouper_next(_grouperobject *igo)
     groupbyobject *gbo = (groupbyobject *)igo->parent;
     PyObject *r;
     int rcmp;
+
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
 
     if (gbo->currvalue == NULL) {
         if (groupby_step(gbo) < 0)
@@ -482,6 +490,10 @@ static PyObject *
 tee_next(teeobject *to)
 {
     PyObject *value, *link;
+
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
 
     if (to->index >= LINKCELLS) {
         link = teedataobject_jumplink(to->dataobj);
@@ -753,6 +765,10 @@ cycle_next(cycleobject *lz)
     PyObject *it;
     PyObject *tmp;
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     while (1) {
         item = PyIter_Next(lz->it);
         if (item != NULL) {
@@ -899,6 +915,10 @@ dropwhile_next(dropwhileobject *lz)
     long ok;
     PyObject *(*iternext)(PyObject *);
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     iternext = *Py_TYPE(it)->tp_iternext;
     for (;;) {
         item = iternext(it);
@@ -1041,6 +1061,10 @@ takewhile_next(takewhileobject *lz)
     PyObject *item, *good;
     PyObject *it = lz->it;
     long ok;
+
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
 
     if (lz->stop == 1)
         return NULL;
@@ -1233,6 +1257,10 @@ islice_next(isliceobject *lz)
     Py_ssize_t oldnext;
     PyObject *(*iternext)(PyObject *);
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     if (it == NULL)
         return NULL;
 
@@ -1382,6 +1410,10 @@ starmap_next(starmapobject *lz)
     PyObject *args;
     PyObject *result;
     PyObject *it = lz->it;
+
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
 
     args = (*Py_TYPE(it)->tp_iternext)(it);
     if (args == NULL)
@@ -1554,6 +1586,10 @@ imap_next(imapobject *lz)
     PyObject *result;
     Py_ssize_t numargs, i;
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     numargs = PyTuple_Size(lz->iters);
     argtuple = PyTuple_New(numargs);
     if (argtuple == NULL)
@@ -1702,6 +1738,10 @@ static PyObject *
 chain_next(chainobject *lz)
 {
     PyObject *item;
+
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
 
     /* lz->source is the iterator of iterables. If it's NULL, we've already
      * consumed them all. lz->active is the current iterator. If it's NULL,
@@ -1923,6 +1963,10 @@ product_next(productobject *lz)
     PyObject *result = lz->result;
     Py_ssize_t npools = PyTuple_GET_SIZE(pools);
     Py_ssize_t i;
+
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
 
     if (lz->stopped)
         return NULL;
@@ -2156,6 +2200,10 @@ combinations_next(combinationsobject *co)
     Py_ssize_t n = PyTuple_GET_SIZE(pool);
     Py_ssize_t r = co->r;
     Py_ssize_t i, j, index;
+
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
 
     if (co->stopped)
         return NULL;
@@ -2405,6 +2453,10 @@ cwr_next(cwrobject *co)
     Py_ssize_t n = PyTuple_GET_SIZE(pool);
     Py_ssize_t r = co->r;
     Py_ssize_t i, j, index;
+
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
 
     if (co->stopped)
         return NULL;
@@ -2666,6 +2718,10 @@ permutations_next(permutationsobject *po)
     Py_ssize_t r = po->r;
     Py_ssize_t i, j, k, index;
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     if (po->stopped)
         return NULL;
 
@@ -2870,6 +2926,10 @@ compress_next(compressobject *lz)
     PyObject *(*selectornext)(PyObject *) = *Py_TYPE(selectors)->tp_iternext;
     int ok;
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     while (1) {
         /* Steps:  get datum, get selector, evaluate selector.
            Order is important (to match the pure python version
@@ -3015,6 +3075,10 @@ ifilter_next(ifilterobject *lz)
     long ok;
     PyObject *(*iternext)(PyObject *);
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     iternext = *Py_TYPE(it)->tp_iternext;
     for (;;) {
         item = iternext(it);
@@ -3159,6 +3223,10 @@ ifilterfalse_next(ifilterfalseobject *lz)
     PyObject *it = lz->it;
     long ok;
     PyObject *(*iternext)(PyObject *);
+
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
 
     iternext = *Py_TYPE(it)->tp_iternext;
     for (;;) {
@@ -3362,6 +3430,10 @@ count_nextlong(countobject *lz)
 {
     PyObject *long_cnt;
     PyObject *stepped_up;
+
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
 
     long_cnt = lz->long_cnt;
     if (long_cnt == NULL) {
@@ -3586,6 +3658,10 @@ izip_next(izipobject *lz)
     PyObject *item;
     PyObject *olditem;
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     if (tuplesize == 0)
         return NULL;
     if (Py_REFCNT(result) == 1) {
@@ -3728,6 +3804,10 @@ repeat_traverse(repeatobject *ro, visitproc visit, void *arg)
 static PyObject *
 repeat_next(repeatobject *ro)
 {
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     if (ro->cnt == 0)
         return NULL;
     if (ro->cnt > 0)
@@ -3931,6 +4011,10 @@ izip_longest_next(iziplongestobject *lz)
     PyObject *it;
     PyObject *item;
     PyObject *olditem;
+
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
 
     if (tuplesize == 0)
         return NULL;

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -2981,6 +2981,10 @@ bytearrayiter_next(bytesiterobject *it)
     PyByteArrayObject *seq;
     PyObject *item;
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     assert(it != NULL);
     seq = it->it_seq;
     if (seq == NULL)

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -2101,6 +2101,10 @@ instance_iternext(PyInstanceObject *self)
 {
     PyObject *func;
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     if (nextstr == NULL) {
         nextstr = PyString_InternFromString("next");
         if (nextstr == NULL)

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2624,6 +2624,10 @@ static PyObject *dictiter_iternextkey(dictiterobject *di)
     register PyDictEntry *ep;
     PyDictObject *d = di->di_dict;
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     if (d == NULL)
         return NULL;
     assert (PyDict_Check(d));
@@ -2696,6 +2700,10 @@ static PyObject *dictiter_iternextvalue(dictiterobject *di)
     register PyDictEntry *ep;
     PyDictObject *d = di->di_dict;
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     if (d == NULL)
         return NULL;
     assert (PyDict_Check(d));
@@ -2767,6 +2775,10 @@ static PyObject *dictiter_iternextitem(dictiterobject *di)
     register Py_ssize_t i, mask;
     register PyDictEntry *ep;
     PyDictObject *d = di->di_dict;
+
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
 
     if (d == NULL)
         return NULL;

--- a/Objects/enumobject.c
+++ b/Objects/enumobject.c
@@ -85,6 +85,10 @@ enum_next_long(enumobject *en, PyObject* next_item)
     PyObject *next_index;
     PyObject *stepped_up;
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     if (en->en_longindex == NULL) {
         en->en_longindex = PyInt_FromSsize_t(PY_SSIZE_T_MAX);
         if (en->en_longindex == NULL) {
@@ -300,6 +304,10 @@ reversed_next(reversedobject *ro)
 {
     PyObject *item;
     Py_ssize_t index = ro->index;
+
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
 
     if (index >= 0) {
         item = PySequence_GetItem(ro->seq, index);

--- a/Objects/fileobject.c
+++ b/Objects/fileobject.c
@@ -2349,6 +2349,10 @@ file_iternext(PyFileObject *f)
 {
     PyStringObject* l;
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     if (f->f_fp == NULL)
         return err_closed();
     if (!f->readable)

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -280,6 +280,10 @@ failed_throw:
 static PyObject *
 gen_iternext(PyGenObject *gen)
 {
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+        
     return gen_send_ex(gen, NULL, 0);
 }
 

--- a/Objects/iterobject.c
+++ b/Objects/iterobject.c
@@ -173,6 +173,10 @@ calliter_traverse(calliterobject *it, visitproc visit, void *arg)
 static PyObject *
 calliter_iternext(calliterobject *it)
 {
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+        
     if (it->it_callable != NULL) {
         PyObject *args = PyTuple_New(0);
         PyObject *result;

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2904,6 +2904,10 @@ listiter_next(listiterobject *it)
     PyListObject *seq;
     PyObject *item;
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     assert(it != NULL);
     seq = it->it_seq;
     if (seq == NULL)

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -239,6 +239,10 @@ typedef struct {
 static PyObject *
 rangeiter_next(rangeiterobject *r)
 {
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+        
     if (r->index < r->len)
         return PyInt_FromLong(r->start + (r->index++) * r->step);
     return NULL;

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -848,6 +848,10 @@ static PyObject *setiter_iternext(setiterobject *si)
     register setentry *entry;
     PySetObject *so = si->si_set;
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     if (so == NULL)
         return NULL;
     assert (PyAnySet_Check(so));

--- a/Objects/stringlib/string_format.h
+++ b/Objects/stringlib/string_format.h
@@ -1088,6 +1088,10 @@ formatteriter_next(formatteriterobject *it)
                                      &field_name, &format_spec, &conversion,
                                      &format_spec_needs_expanding);
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     /* all of the SubString objects point into it->str, so no
        memory management needs to be done on them */
     assert(0 <= result && result <= 2);
@@ -1240,6 +1244,10 @@ fieldnameiter_next(fieldnameiterobject *it)
     int is_attr;
     Py_ssize_t idx;
     SubString name;
+
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
 
     result = FieldNameIterator_next(&it->it_field, &is_attr,
                                     &idx, &name);

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -950,6 +950,10 @@ tupleiter_next(tupleiterobject *it)
     PyTupleObject *seq;
     PyObject *item;
 
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+
     assert(it != NULL);
     seq = it->it_seq;
     if (seq == NULL)

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -609,6 +609,10 @@ proxy_iter(PyWeakReference *proxy)
 static PyObject *
 proxy_iternext(PyWeakReference *proxy)
 {
+    if (PyErr_WarnPy3k_WithFix("the attribute 'next' is not supported in 3.x", 
+                               "use '__next__' or create a 'next' alias", 1) < 0)
+        return NULL;
+        
     if (!proxy_checkref(proxy))
         return NULL;
     return PyIter_Next(PyWeakref_GET_OBJECT(proxy));


### PR DESCRIPTION
Warn for next() -> __next__()

```
py2.x:

 def next(self):
        try:
            f = self.files.pop(0)
        except IndexError:
            raise StopIteration
        else:
            s = self.server.avatar._runAsUser(
                os.lstat, os.path.join(self.dir, f))
            longname = lsLine(f, s)
            attrs = self.server._getAttrs(s)
            return (f, longname, attrs)

py3.x:

 def __next__(self):
        try:
            f = self.files.pop(0)
        except IndexError:
            raise StopIteration
        else:
            s = self.server.avatar._runAsUser(
                os.lstat, os.path.join(self.dir, f))
            longname = lsLine(f, s)
            attrs = self.server._getAttrs(s)
            return (f, longname, attrs)

    next = __next__ 

python 2.x:

>>> marks = [65, 71, 68, 74, 61]
>>> iterator_marks = iter(marks)
>>> marks_1 = next(iterator_marks)
>>> iterator_marks.next()
71
>>> iterator_marks.__next__()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'listiterator' object has no attribute '__next__'
>>> 

python 3.x:

>>> marks = [65, 71, 68, 74, 61]
>>> iterator_marks = iter(marks)
>>> marks_1 = next(iterator_marks)
>>> marks_1 = __next__(iterator_marks)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name '__next__' is not defined
>>> iterator_marks.next()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'list_iterator' object has no attribute 'next'
>>> iterator_marks.__next__()
71
```
