### PR TITLE
Warn for exception: move warning to ceval

### DIFF
--- a/Lib/test/test_py3kwarn.py
+++ b/Lib/test/test_py3kwarn.py
@@ -258,6 +258,22 @@ class TestPy3KWarnings(unittest.TestCase):
         c = C()
         with check_py3k_warnings() as w:
             self.assertWarning(dir(c), w, expected)
+    
+    def test_sys_exc_info(self):
+        expected = 'sys.exc_info() not supported in 3.x: use except clauses.'
+        with check_py3k_warnings() as w:
+            self.assertWarning(sys.exc_info(), w, expected)
+
+    def test_exception_iterable(self):
+        def helperftn():
+            try:
+                pass
+            except RuntimeError as (num, message):
+                return None
+        expected = "Iterable exceptions are not supported in 3.x: access the arguments through the 'args' attribute instead"
+        with check_py3k_warnings() as w:
+            self.assertWarning(helperftn, w, expected)
+
 
     def test_softspace(self):
         expected = 'file.softspace not supported in 3.x'

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4870,7 +4870,11 @@ cmp_outcome(int op, register PyObject *v, register PyObject *w)
                         CANNOT_CATCH_MSG, 1);
                     if (ret_val < 0)
                         return NULL;
-                }
+                    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                        "Iterable exceptions are not supported in 3.x"
+                        "access the arguments through the 'args' attribute instead", 1) < 0)
+                            return NULL;
+                    }
             }
         }
         else {

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -149,6 +149,14 @@ PyDoc_STRVAR(excepthook_doc,
 static PyObject *
 sys_exc_info(PyObject *self, PyObject *noargs)
 {
+    if (Py_Py3kWarningFlag) {
+        if (PyErr_WarnExplicit_WithFix(PyExc_Py3xWarning, 
+                                      "sys.exc_info() not supported in 3.x", 
+                                      "use except clauses", NULL, NULL, 
+                                      NULL, NULL)) {
+            return NULL;
+        }
+    }
     PyThreadState *tstate;
     tstate = PyThreadState_GET();
     return Py_BuildValue(


### PR DESCRIPTION
This replaces the old PR: https://github.com/softdevteam/pygrate2/pull/12
Moved the warning to ceval.

I removed the three component warning because it was committed in an earlier PR here: https://github.com/softdevteam/pygrate2/pull/14