### PR TITLE
warn for truncate

### DIFF
--- a/Lib/test/test_py3kwarn.py
+++ b/Lib/test/test_py3kwarn.py
@@ -308,6 +308,14 @@ class TestPy3KWarnings(unittest.TestCase):
             with check_py3k_warnings() as w:
                 self.assertWarning(f.xreadlines(), w, expected)
 
+    def test_bytesio_truncate(self):
+        from io import BytesIO
+        x = BytesIO(b'AAAAAA')
+        expected = "BytesIO.truncate() does not shift the file pointer: use seek(0) before doing truncate(0)"
+        self.assertWarning(x.truncate(0), w, expected)
+        w.reset()
+        self.assertNoWarning(x.truncate(-1), w)
+
     def test_file_open(self):
         expected = ("The builtin 'file()'/'open()' function is not supported in 3.x, "
                        "use the 'io.open()' function instead with the encoding keyword argument")

--- a/Modules/_io/bytesio.c
+++ b/Modules/_io/bytesio.c
@@ -447,6 +447,10 @@ bytesio_truncate(bytesio *self, PyObject *args)
         size = PyNumber_AsSsize_t(arg, PyExc_OverflowError);
         if (size == -1 && PyErr_Occurred())
             return NULL;
+        if (size == 0 && PyErr_WarnPy3k_WithFix("BytesIO.truncate() does not shift the file pointer",
+                       "use seek(0) before doing truncate(0)", 1) < 0){
+            return NULL;
+        }
     }
     else if (arg == Py_None) {
         /* Truncate to current position if no argument is passed. */


### PR DESCRIPTION
Use seek(0) before doing truncate(0)

    BytesIO.truncate() does not shift the file pointer,
    so we need to seek() to move the file pointer,
    otherwise writing after truncating will mess up the
    stream.

    s.truncate(0) -> s.seek(0)
                     s.truncate(0)