### PR TITLE
String warnings

### DIFF
--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -1067,6 +1067,12 @@ class MixinStrUnicodeUserStringTest(NonStringModuleTest):
                isinstance(b"fix", basestring)
                isinstance("fix", basestring)
 
+    def test_py3x_warnings_compare(self):
+       if sys.py3kwarning:
+           with test_support.check_py3k_warnings():
+            self.assertRaises(Py3xWarning, b"hello" == u"hello", 
+                              "comparing unicode and byte strings is not supported in 3.x: convert the second string to byte.")
+
     def test_py3x_warnings_join(self):
         if sys.py3kwarning:
            with warnings.catch_warnings(record=True) as w:
@@ -1388,11 +1394,14 @@ class MixinStrUserStringTest:
         self.checkraises(TypeError, 'xyz', 'encode', 42)
 
         with test_support.check_py3k_warnings():
-            self.assertRaises(Py3xWarning, b"test".encode, "encoding Bytes is not supported in 3.x: convert the byte string to unicode before encoding")
+            self.assertRaises(Py3xWarning, b"test".encode, 
+                              "encoding Bytes is not supported in 3.x: convert the byte string to unicode before encoding")
 
         with test_support.check_py3k_warnings():
-            self.assertRaises(Py3xWarning, str(3), "the constructors of both 'str' and 'bytes' have different semantics in 3.x: use 'str' for unicode or 'bytes' for byte strings.")
-            self.assertRaises(Py3xWarning, bytes(3), "the constructors of both 'str' and 'bytes' have different semantics in 3.x: use 'str' for unicode or 'bytes' for byte strings.")
+            self.assertRaises(Py3xWarning, str(3), 
+                              "the constructors of both 'str' and 'bytes' have different semantics in 3.x: use 'str' for unicode or 'bytes' for byte strings.")
+            self.assertRaises(Py3xWarning, bytes(3), 
+                              "the constructors of both 'str' and 'bytes' have different semantics in 3.x: use 'str' for unicode or 'bytes' for byte strings.")
 
 
 class MixinStrUnicodeTest:

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -1388,7 +1388,11 @@ class MixinStrUserStringTest:
         self.checkraises(TypeError, 'xyz', 'encode', 42)
 
         with test_support.check_py3k_warnings():
-            self.assertRaises(Py3xWarning, b"test".encode, "encoding Bytes is not supported in 3.x", "convert the byte string to unicode before encoding")
+            self.assertRaises(Py3xWarning, b"test".encode, "encoding Bytes is not supported in 3.x: convert the byte string to unicode before encoding")
+
+        with test_support.check_py3k_warnings():
+            self.assertRaises(Py3xWarning, str(3), "the constructors of both 'str' and 'bytes' have different semantics in 3.x: use 'str' for unicode or 'bytes' for byte strings.")
+            self.assertRaises(Py3xWarning, bytes(3), "the constructors of both 'str' and 'bytes' have different semantics in 3.x: use 'str' for unicode or 'bytes' for byte strings.")
 
 
 class MixinStrUnicodeTest:

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -1387,6 +1387,9 @@ class MixinStrUserStringTest:
         self.checkraises(TypeError, 'xyz', 'decode', 42)
         self.checkraises(TypeError, 'xyz', 'encode', 42)
 
+        with test_support.check_py3k_warnings():
+            self.assertRaises(Py3xWarning, b"test".encode, "encoding Bytes is not supported in 3.x", "convert the byte string to unicode before encoding")
+
 
 class MixinStrUnicodeTest:
     # Additional tests that only work with str and unicode.

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -1399,9 +1399,9 @@ class MixinStrUserStringTest:
 
         with test_support.check_py3k_warnings():
             self.assertRaises(Py3xWarning, str(3), 
-                              "the constructors of both 'str' and 'bytes' have different semantics in 3.x: use 'str' for unicode or 'bytes' for byte strings.")
+                              "comparing unicode and byte strings has different semantics in 3.x: use 'str' for unicode or 'bytes' for byte strings.")
             self.assertRaises(Py3xWarning, bytes(3), 
-                              "the constructors of both 'str' and 'bytes' have different semantics in 3.x: use 'str' for unicode or 'bytes' for byte strings.")
+                              "comparing unicode and byte strings has different semantics in 3.x: use 'str' for unicode or 'bytes' for byte strings.")
 
 
 class MixinStrUnicodeTest:

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -280,7 +280,8 @@ class UnicodeTest(
         self.assertTrue(u'\ud800\udc02' < u'\ud84d\udc56')
 
         with test_support.check_py3k_warnings():
-            self.assertRaises(Py3xWarning, u"hello" == b"hello", "comparing unicode and byte strings is not supported in 3.x: convert the second string to unicode.")
+            self.assertRaises(Py3xWarning, u"hello" == b"hello", 
+                              "comparing unicode and byte strings has different semantics in 3.x: convert the second string to unicode.")
 
     def test_capitalize(self):
         string_tests.CommonTest.test_capitalize(self)

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -279,6 +279,9 @@ class UnicodeTest(
         # Surrogates on both sides, no fixup required
         self.assertTrue(u'\ud800\udc02' < u'\ud84d\udc56')
 
+        with test_support.check_py3k_warnings():
+            self.assertRaises(Py3xWarning, u"hello" == b"hello", "comparing unicode and byte strings is not supported in 3.x: convert the second string to unicode.")
+
     def test_capitalize(self):
         string_tests.CommonTest.test_capitalize(self)
         # check that titlecased chars are lowered correctly

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -1045,6 +1045,7 @@ class UnicodeTest(
                              u'abcde'.decode(encoding='ascii', errors='replace'))
         with test_support.check_py3k_warnings():
             self.assertRaises(Py3xWarning, u"test".decode, "decoding Unicode is not supported in 3.x: convert the unicode string to bytes before decoding.")
+            self.assertRaises(Py3xWarning, unicode("test"), "the unicode constructor is not supported in 3.x": "use 'str' for unicode or 'bytes' for byte strings.")
 
         # Error handling (unknown character names)
         self.assertEqual("\\N{foo}xx".decode("unicode-escape", "ignore"), u"xx")

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -1043,6 +1043,8 @@ class UnicodeTest(
         with test_support.check_py3k_warnings():
             self.assertEqual(u'abcde'.decode('ascii', 'replace'),
                              u'abcde'.decode(encoding='ascii', errors='replace'))
+        with test_support.check_py3k_warnings():
+            self.assertRaises(Py3xWarning, u"test".decode, "decoding Unicode is not supported in 3.x: convert the unicode string to bytes before decoding.")
 
         # Error handling (unknown character names)
         self.assertEqual("\\N{foo}xx".decode("unicode-escape", "ignore"), u"xx")

--- a/Objects/stringobject.c
+++ b/Objects/stringobject.c
@@ -3718,6 +3718,10 @@ string_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     PyObject *x = NULL;
     static char *kwlist[] = {"object", 0};
 
+    if (PyErr_WarnPy3k_WithFix("the constructors of both 'str' and 'bytes' have different semantics in 3.x", 
+                                "use 'str' for unicode or 'bytes' for byte strings.", 1) < 0)
+        return NULL;
+
     if (type != &PyString_Type)
         return str_subtype_new(type, args, kwds);
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O:str", kwlist, &x))

--- a/Objects/stringobject.c
+++ b/Objects/stringobject.c
@@ -1221,6 +1221,10 @@ string_richcompare(PyStringObject *a, PyStringObject *b, int op)
 
     /* Make sure both arguments are strings. */
     if (!(PyString_Check(a) && PyString_Check(b))) {
+        if (PyErr_WarnPy3k_WithFix("comparing unicode and byte strings is not supported in 3.x", 
+                                "convert the second string to byte.", 1) < 0)
+        return NULL;
+        
         result = Py_NotImplemented;
         goto out;
     }

--- a/Objects/stringobject.c
+++ b/Objects/stringobject.c
@@ -1219,12 +1219,12 @@ string_richcompare(PyStringObject *a, PyStringObject *b, int op)
     Py_ssize_t min_len;
     PyObject *result;
 
-    /* Make sure both arguments are strings. */
-    if (!(PyString_Check(a) && PyString_Check(b))) {
-        if (PyErr_WarnPy3k_WithFix("comparing unicode and byte strings is not supported in 3.x", 
+    if (!PyString_Check(a) && PyErr_WarnPy3k_WithFix("comparing unicode and byte strings has different semantics in 3.x", 
                                 "convert the second string to byte.", 1) < 0)
         return NULL;
-        
+
+    /* Make sure both arguments are strings. */
+    if (!(PyString_Check(a) && PyString_Check(b))) {
         result = Py_NotImplemented;
         goto out;
     }

--- a/Objects/stringobject.c
+++ b/Objects/stringobject.c
@@ -3024,6 +3024,10 @@ string_encode(PyStringObject *self, PyObject *args, PyObject *kwargs)
     char *errors = NULL;
     PyObject *v;
 
+    if (PyErr_WarnPy3k_WithFix("encoding Bytes is not supported in 3.x", 
+                                "convert the byte string to unicode before encoding", 1) < 0)
+        goto onError;
+
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|ss:encode",
                                      kwlist, &encoding, &errors))
         return NULL;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -1304,9 +1304,6 @@ PyObject *PyUnicode_AsDecodedObject(PyObject *unicode,
         goto onError;
     }
 
-    if (PyErr_WarnPy3k("decoding Unicode is not supported in 3.x", 1) < 0)
-        goto onError;
-
     if (encoding == NULL)
         encoding = PyUnicode_GetDefaultEncoding();
 
@@ -6499,6 +6496,10 @@ unicode_decode(PyUnicodeObject *self, PyObject *args, PyObject *kwargs)
     char *encoding = NULL;
     char *errors = NULL;
     PyObject *v;
+
+    if (PyErr_WarnPy3k_WithFix("decoding Unicode is not supported in 3.x", 
+                                "convert the unicode string to bytes before decoding", 1) < 0)
+        goto onError;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|ss:decode",
                                      kwlist, &encoding, &errors))

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -8849,6 +8849,10 @@ unicode_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     char *encoding = NULL;
     char *errors = NULL;
 
+    if (PyErr_WarnPy3k_WithFix("the unicode constructor is not supported in 3.x", 
+                                "use 'str' for unicode instead.", 1) < 0)
+        return NULL;
+
     if (type != &PyUnicode_Type)
         return unicode_subtype_new(type, args, kwds);
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|Oss:unicode",

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -6233,7 +6233,7 @@ int PyUnicode_Compare(PyObject *left,
     PyUnicodeObject *u = NULL, *v = NULL;
     int result;
 
-    if (!PyUnicode_Check(right) && PyErr_WarnPy3k_WithFix("comparing unicode and byte strings is not supported in 3.x", 
+    if (!PyUnicode_Check(right) && PyErr_WarnPy3k_WithFix("comparing unicode and byte strings has different semantics in 3.x", 
                                 "convert the second string to unicode.", 1) < 0)
         return NULL;
 

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -6233,6 +6233,10 @@ int PyUnicode_Compare(PyObject *left,
     PyUnicodeObject *u = NULL, *v = NULL;
     int result;
 
+    if (!PyUnicode_Check(right) && PyErr_WarnPy3k_WithFix("comparing unicode and byte strings is not supported in 3.x", 
+                                "convert the second string to unicode.", 1) < 0)
+        return NULL;
+
     /* Coerce the two arguments */
     u = (PyUnicodeObject *)PyUnicode_FromObject(left);
     if (u == NULL)

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1401,11 +1401,9 @@ tok_get(register struct tok_state *tok, char **p_start, char **p_end)
                 c = tok_nextc(tok);
             }
             else {
-                if (Py_Py3kWarningFlag) {
-                    if (PyErr_WarnExplicit_WithFix(PyExc_Py3xWarning, "the unicode type is not supported in 3.x", 
-                                                   "use native strings for compatibility or "
-                                                   "a 'u' or 'b' prefix if a native string is not required", 
-                                                   tok->filename, tok->lineno, NULL, NULL)) {
+                if (PyErr_WarnExplicit_WithFix(PyExc_Py3xWarning, "the 'unicode' type is not explicitly supported in 3.x", 
+                                                "strings with a 'u' prefix are evaluated as type 'str'.", 
+                                                tok->filename, tok->lineno, NULL, NULL)) {
                         return NULL;
                     }
                 }
@@ -1460,15 +1458,15 @@ tok_get(register struct tok_state *tok, char **p_start, char **p_end)
             if (c == 'j' || c == 'J')
                 goto imaginary;
 #endif
-            if (c != 'o' || c != 'O') {
-                char buf[100];
-                if (Py_Py3kWarningFlag) {
-                    if (PyErr_WarnExplicit_WithFix(PyExc_Py3xWarning, "using just a '0' prefix for octal literals is not supported in 3.x", 
-                                                   "use the '0o' prefix for octal integers, if you intended the integer to be decimal", tok->filename, tok->lineno, NULL, NULL)) {
-                        return NULL;
-                    }
-                }
-            }
+            // if (c != 'o' || c != 'O') {
+            //     char buf[100];
+            //     if (Py_Py3kWarningFlag) {
+            //         if (PyErr_WarnExplicit_WithFix(PyExc_Py3xWarning, "using just a '0' prefix for octal literals is not supported in 3.x", 
+            //                                        "use the '0o' prefix for octal integers, if you intended the integer to be decimal", tok->filename, tok->lineno, NULL, NULL)) {
+            //             return NULL;
+            //         }
+            //     }
+            // }
             if (c == 'x' || c == 'X') {
 
                 /* Hex */

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1406,7 +1406,7 @@ tok_get(register struct tok_state *tok, char **p_start, char **p_end)
                                                 tok->filename, tok->lineno, NULL, NULL)) {
                         return NULL;
                     }
-                }
+                
 
             }
             if (c == '"' || c == '\'')


### PR DESCRIPTION




# encode/decode

**unicode**

Encode and Decode bytes
Py2.x:

>>> y = "f"
>>> type(y)
<type 'str'>
>>> x = y.encode('utf-8')
>>> type(x)
<type 'str'>
>>> c = y.decode('utf-8')
>>> type(c)
<type 'unicode'>

Py3.x:

>>> y = "f"
>>> type(y)
<class 'str'>
>>> x = y.encode('utf-8')
>>> type(x)
<class 'bytes'>
>>> c = y.decode('utf-8')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'str' object has no attribute 'decode'
>>>

Based on our assumption the encode() method is consistent, and will change the string to bytes. Decode won’t work, because the str type does not
support the decode method.

Likewise bytes in py3.x cant be encoded using the encode() method, you can only decode them back to unicode:

>>> b = "fg"
>>> type(b)
<class 'str'>
>>> c = b.encode('utf-8')
>>> type(c)
<class 'bytes'>
>>> d = b.decode('utf-8')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'str' object has no attribute 'decode'
>>> by = b"df"
>>> x = by.encode('utf-8')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'bytes' object has no attribute 'encode'
>>> y = by.dencode('utf-8')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'bytes' object has no attribute 'dencode'
>>> y = by.decode('utf-8')
>>> type(y)
<class 'str'>
>>> type(by)
<class 'bytes'>

But Python 2 will just detect that encode shouldn’t be applied and just keep the current format of the string.

# constructors

**unicode**

py2.x:

>>> unicode(3)
u'3'

py3.x:
>>> unicode(3)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'unicode' is not defined

**str/bytes**

py2.x:
>>> str(b'3')
'3'
>>> bytes(b'3')
'3'

py3.x:
>>> bytes(3)
b'\x00\x00\x00'
>>> str(b'3')
"b'3'"


do we forward port anything to preserve py2.x semantics ?

# implicit conversion**

py2.x:
>>> "fg" + b"jk"
'fgjk'
>>> "hello" + b"hello"
'hellohello'
>>> "hello" == b"hello"
True
>>> dict = {"key": "value"}
>>> dict[b"key"]
'value'

py3.x:

>>> "fg" + b"jk"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: can only concatenate str (not "bytes") to str
>>> "hello" == b"hello"
False
>>> dict = {"key": "value"}
>>> dict[b"key"]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
KeyError: b'key'