### PR TITLE
Fix regression

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -690,6 +690,7 @@ the variables:
    single: PyExc_SyntaxWarning
    single: PyExc_UnicodeWarning
    single: PyExc_UserWarning
+   single: PyExc_Py3xWarning
 
 +------------------------------------------+---------------------------------+----------+
 | C Name                                   | Python Name                     | Notes    |
@@ -713,6 +714,8 @@ the variables:
 | :c:data:`PyExc_UnicodeWarning`           | :exc:`UnicodeWarning`           |          |
 +------------------------------------------+---------------------------------+----------+
 | :c:data:`PyExc_UserWarning`              | :exc:`UserWarning`              |          |
++------------------------------------------+---------------------------------+----------+
+| :c:data:`PyExc_3xWarning`                | :exc:`Py3xWarning`                |          |
 +------------------------------------------+---------------------------------+----------+
 
 Notes:

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -530,6 +530,10 @@ module for more information.
 
    .. versionadded:: 2.6
 
+.. exception:: Py3xWarning
+
+   Base class for warnings about 3.x compatibility.
+
 
 Exception hierarchy
 -------------------

--- a/Doc/library/warnings.rst
+++ b/Doc/library/warnings.rst
@@ -94,6 +94,9 @@ following warnings category classes are currently defined:
 | :exc:`BytesWarning`              | Base category for warnings related to         |
 |                                  | bytes and bytearray.                          |
 +----------------------------------+-----------------------------------------------+
+| :exc:`Py3xWarning`               | Base class for warnings about 3.x             |
+                                   | compatibility                                 |                         |
++----------------------------------+-----------------------------------------------+
 
 While these are technically built-in exceptions, they are documented here,
 because conceptually they belong to the warnings mechanism.

--- a/Include/pyerrors.h
+++ b/Include/pyerrors.h
@@ -177,6 +177,7 @@ PyAPI_DATA(PyObject *) PyExc_FutureWarning;
 PyAPI_DATA(PyObject *) PyExc_ImportWarning;
 PyAPI_DATA(PyObject *) PyExc_UnicodeWarning;
 PyAPI_DATA(PyObject *) PyExc_BytesWarning;
+PyAPI_DATA(PyObject *) PyExc_Py3xWarning;
 
 
 /* Convenience functions */

--- a/Lib/test/exception_hierarchy.txt
+++ b/Lib/test/exception_hierarchy.txt
@@ -45,6 +45,7 @@ BaseException
            +-- SyntaxWarning
            +-- UserWarning
            +-- FutureWarning
+           +-- Py3xWarning
 	   +-- ImportWarning
 	   +-- UnicodeWarning
 	   +-- BytesWarning

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -494,8 +494,12 @@ class ASTHelpers_Test(unittest.TestCase):
 
 
 def test_main():
-    with test_support.check_py3k_warnings(("backquote not supported",
-                                             SyntaxWarning)):
+    deprecations = []
+    if sys.py3kwarning:
+        deprecations += [
+            ("backquote not supported", SyntaxWarning),
+            ("the L suffix is not supported in 3.x; drop the suffix", SyntaxWarning)]
+    with test_support.check_warnings(*deprecations):
         test_support.run_unittest(AST_Tests, ASTHelpers_Test)
 
 def main():

--- a/Lib/test/test_optparse.py
+++ b/Lib/test/test_optparse.py
@@ -1655,9 +1655,8 @@ class TestParseNumber(BaseTest):
                              "option -l: invalid long integer value: '0x12x'")
 
     def test_parse_num_3k_warnings(self):
-        expected = 'the L suffix is not supported in 3.x; simply drop the suffix, \
-                    or accept the auto fixer modifications'
-        with check_py3k_warnings((expected, Py3xWarning)):
+        expected = 'the L suffix is not supported in 3.x; drop the suffix'
+        with test_support.check_warnings():
             x = 10L
             y = 8L
             z = x + y

--- a/Lib/test/test_optparse.py
+++ b/Lib/test/test_optparse.py
@@ -1654,6 +1654,16 @@ class TestParseNumber(BaseTest):
         self.assertParseFail(["-l", "0x12x"],
                              "option -l: invalid long integer value: '0x12x'")
 
+    def test_parse_num_3k_warnings(self):
+        expected = 'the L suffix is not supported in 3.x; simply drop the suffix, \
+                    or accept the auto fixer modifications'
+        with check_py3k_warnings((expected, Py3xWarning)):
+            x = 10L
+            y = 8L
+            z = x + y
+            a = x * y
+            b = x - y
+
 
 def test_main():
     test_support.run_unittest(__name__)

--- a/Misc/Vim/python.vim
+++ b/Misc/Vim/python.vim
@@ -92,6 +92,7 @@ if exists("python_highlight_exceptions")
   syn keyword pythonException    ReferenceError RuntimeError RuntimeWarning
   syn keyword pythonException    StandardError StopIteration SyntaxError
   syn keyword pythonException    SyntaxWarning SystemError SystemExit TabError
+  syn keyword pythonException    Py3xWarning SystemError SystemExit Warning
   syn keyword pythonException    TypeError UnboundLocalError UnicodeDecodeError
   syn keyword pythonException    UnicodeEncodeError UnicodeError
   syn keyword pythonException    UnicodeTranslateError UnicodeWarning

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -1982,6 +1982,13 @@ SimpleExtendsException(PyExc_Warning, SyntaxWarning,
 
 
 /*
+ *    3xWarning extends Warning
+ */
+SimpleExtendsException(PyExc_Warning, Py3xWarning,
+                       "Base class for warnings about 3.x compatibility.");
+
+
+/*
  *    RuntimeWarning extends Warning
  */
 SimpleExtendsException(PyExc_Warning, RuntimeWarning,
@@ -2104,6 +2111,7 @@ _PyExc_Init(void)
     PRE_INIT(ImportWarning)
     PRE_INIT(UnicodeWarning)
     PRE_INIT(BytesWarning)
+    PRE_INIT(Py3xWarning)
 
     m = Py_InitModule4("exceptions", functions, exceptions_doc,
         (PyObject *)NULL, PYTHON_API_VERSION);
@@ -2173,6 +2181,7 @@ _PyExc_Init(void)
     POST_INIT(ImportWarning)
     POST_INIT(UnicodeWarning)
     POST_INIT(BytesWarning)
+    POST_INIT(Py3xWarning)
 
     PyExc_MemoryErrorInst = BaseException_new(&_PyExc_MemoryError, NULL, NULL);
     if (!PyExc_MemoryErrorInst)

--- a/PC/os2emx/python27.def
+++ b/PC/os2emx/python27.def
@@ -819,6 +819,7 @@ EXPORTS
   "PyExc_DeprecationWarning"
   "PyExc_PendingDeprecationWarning"
   "PyExc_SyntaxWarning"
+  "PyExc_Py3xWarning"
   "PyExc_RuntimeWarning"
   "PyExc_FutureWarning"
   "PyExc_ImportWarning"

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -131,19 +131,6 @@ ast_warn(struct compiling *c, const node *n, char *msg)
 }
 
 static int
-ast_3x_warn(struct compiling *c, const node *n, char *msg)
-{
-    if (PyErr_WarnExplicit(PyExc_Py3xWarning, msg, c->c_filename, LINENO(n),
-                           NULL, NULL) < 0) {
-        /* if -Werr, change it to a SyntaxError */
-        if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_Py3xWarning))
-            ast_error(n, msg);
-        return 0;
-    }
-    return 1;
-}
-
-static int
 forbidden_check(struct compiling *c, const node *n, const char *x)
 {
     if (!strcmp(x, "None"))
@@ -3355,8 +3342,7 @@ parsenumber(struct compiling *c, const node *n, const char *s)
 #endif
         if (*end == 'l' || *end == 'L') {
                 if (Py_Py3kWarningFlag &&
-                    !ast_3x_warn(c, n, "the L suffix is not supported in 3.x; simply drop the suffix, \n" 
-                                 "or accept the auto fixer modifications")) {
+                    !ast_warn(c, n, "the L suffix is not supported in 3.x; drop the suffix")) {
                         return NULL;
                 }
                 return PyLong_FromString((char *)s, (char **)0, 0);


### PR DESCRIPTION
I am trying to have a green run for running tests the` py -3 `way i.e:

`./python -3 -m test`

I introduced a regression early on that I didn't notice early enough.
I tracked it down to:

- My first PR modified AST introducing `ast_warn()` in `ast.c` with custom filters for the Py3XWarning flag
- The problem is, in the tests how do we track warnings from the previous py3kWarning/SyntaxWarning flag as well as ours in the new flag
- Therefore, the plumbing has to be rewritten

It means I may edit several already written warnings, will do it in small PRs unless they start to seem related.

Merge this PR on a separate `fix_regression` branch until I update all areas to reflect the warning changes.
We will merge this branch on migration then.

