### PR TITLE
Track for new and join on both str and unicode

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -105,6 +105,7 @@ whose size is determined when the object is allocated.
  */
 typedef struct _object {
     PyObject_HEAD
+    Py_ssize_t ob_bstate;
 } PyObject;
 
 typedef struct {

--- a/Lib/test/test_StringIO.py
+++ b/Lib/test/test_StringIO.py
@@ -183,6 +183,10 @@ class TestStringIO(TestGenericStringIO):
         with test_support.check_py3k_warnings(*deprecations):
             "test str" == u"test unicode"
 
+    def test_py3k_join(self):
+        with test_support.check_py3k_warnings(*deprecations):
+            "test str" + u"test unicode"
+
 class TestcStringIO(TestGenericStringIO):
     MODULE = cStringIO
 

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -1020,6 +1020,11 @@ class UnicodeTest(
         # Test whether trailing dot is preserved
         self.assertEqual(u"www.python.org.".encode("idna"), "www.python.org.")
 
+    def test_3k_join(self):
+        with test_support.check_py3k_warnings():
+            u"test unicode" + "test str"
+
+
     def test_codecs_errors(self):
         # Error handling (encoding)
         self.assertRaises(UnicodeError, u'Andr\202 x'.encode, 'ascii')

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -5673,6 +5673,16 @@ PyUnicode_Join(PyObject *separator, PyObject *seq)
     PyObject *item;
     Py_ssize_t i;
 
+    // if (!PyUnicode_Check(seq) && !seq->ob_bstate == NULL) {
+    //     if (PyErr_WarnPy3k("Concatenation only works for unicode to unicode in 3.x: convert the string to unicode.", 1) < 0) {
+    //         return NULL;
+    //     }
+    // }
+
+    // if (!PyUnicode_Check(seq) && seq->ob_bstate == NULL) {
+    //     seq->ob_bstate = BSTATE_UNICODE;
+    // }
+
     fseq = PySequence_Fast(seq, "can only join an iterable");
     if (fseq == NULL) {
         return NULL;
@@ -8859,6 +8869,7 @@ unicode_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return NULL;
     if (x == NULL)
         return (PyObject *)_PyUnicode_New(0);
+    // x->ob_bstate = BSTATE_UNICODE;
     if (encoding == NULL && errors == NULL)
         return PyObject_Unicode(x);
     else


### PR DESCRIPTION
Tracking for new and join operations, applied to both unicode and bytes.

This tracking breaks ordinal configurations for unicode, so before I reconfigure, let us confirm with this PR if this is the intended design from our discussion of the minimal example in the google doc on the string assumptions.