### PR TITLE
Add warning for base64 encode functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 *.profclang?
 *.profraw
 *.dyn
+.history/
 Doc/build/
 Doc/venv/
 Doc/.venv/

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -9,7 +9,8 @@ import re
 import struct
 import string
 import binascii
-from warnings import warnpy3k_with_fix
+from warnings import warnpy3k_with_fix, warnpy3k
+from functools import wraps
 
 
 __all__ = [
@@ -366,6 +367,21 @@ def test1():
     s2 = decodestring(s1)
     print s0, repr(s1), s2
 
+
+def _warn_encode(func, name):
+    @wraps(func)
+    def encode_wrapper(*args, **kwargs):
+        warnpy3k(
+            "base64.{0} returns str in Python 2 (bytes in 3.x)".format(name),
+            UserWarning,
+            stacklevel= 2,
+            )
+        return func(*args, **kwargs)
+    return encode_wrapper
+
+
+for _name in ["b64encode", "b32encode", "b16encode"]:
+    globals()[_name] = _warn_encode(globals()[_name], _name)
 
 if __name__ == '__main__':
     test()

--- a/Lib/test/test_py3kwarn.py
+++ b/Lib/test/test_py3kwarn.py
@@ -2,6 +2,7 @@ import unittest
 import sys
 from test.test_support import check_py3k_warnings, CleanImport, run_unittest
 import warnings
+import base64
 from test import test_support
 
 if not sys.py3kwarning:
@@ -384,7 +385,22 @@ class TestPy3KWarnings(unittest.TestCase):
                     use 'raise' with a single object"""
         with check_py3k_warnings() as w:
             excType, excValue, excTraceback = sys.exc_info()
-
+            
+    def test_b64encode_warns(self):
+        expected = "base64.b64encode returns str in Python 2 (bytes in 3.x)"
+        base64.b64encode(b'test')
+        check_py3k_warnings(expected, UserWarning)
+        
+    def test_b32encode_warns(self):
+        expected = "base64.b32encode returns str in Python 2 (bytes in 3.x)"
+        base64.b32encode(b'test')
+        check_py3k_warnings(expected, UserWarning)
+    
+    def test_b16encode_warns(self):
+        expected = "base64.b16encode returns str in Python 2 (bytes in 3.x)"
+        base64.b16encode(b'test')
+        check_py3k_warnings(expected, UserWarning)
+        
 
 class TestStdlibRemovals(unittest.TestCase):
 


### PR DESCRIPTION
Add a wrapper in base64.py that wrap b64encode, b32encode, b16encode, encodebytes, allowing them to warn user the behavior difference between python2 and python3. Methods' name are listed in the warning message.

warning is as following:
<img width="1089" height="187" alt="image" src="https://github.com/user-attachments/assets/ff0ddfe4-5ea0-464a-8b7a-7bb16c859a2f" />



Add test functions in test_base64.py to test whether warning messages shows up.