### PR TITLE
Add Warning For String Concatenation: unicode + byte

### DIFF
--- a/Lib/test/test_py3kwarn.py
+++ b/Lib/test/test_py3kwarn.py
@@ -384,6 +384,20 @@ class TestPy3KWarnings(unittest.TestCase):
                     use 'raise' with a single object"""
         with check_py3k_warnings() as w:
             excType, excValue, excTraceback = sys.exc_info()
+            
+    def test_string_concat(self):
+        expected = "The first string is 'unicode' while the second is 'str': "\
+                "mixed bytes, str and unicode operands cannot be used in string concatenation in Python 3.x"
+                
+        a = u"a"
+        b = b"b"
+        c = a + b
+    
+        check_py3k_warnings(expected)
+            
+            
+
+
 
 
 class TestStdlibRemovals(unittest.TestCase):

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -6396,6 +6396,18 @@ PyObject *PyUnicode_Concat(PyObject *left,
         goto onError;
     }
 
+    if (left->ob_type != right->ob_type) {
+        char msgbuf[256];
+        sprintf(msgbuf, "The first string is '%.200s' while the second is '%.200s': "\
+                "mixed bytes, str and unicode operands cannot be used in string concatenation in Python 3.x", 
+                Py_TYPE(left)->tp_name, Py_TYPE(right)->tp_name);
+        char *fix = "convert the operand(s) so that they are the same type.";
+        if (Py_Py3kWarningFlag &&
+            PyErr_WarnEx_WithFix(PyExc_Py3xWarning, msgbuf, fix, 1) < 0) {
+            return NULL;
+        }
+    }
+
     /* Concat the two Unicode strings */
     w = _PyUnicode_New(u->length + v->length);
     if (w == NULL)


### PR DESCRIPTION
Modified PyUnicode_Concat in unicodeobject.c to warn users with fix about Concatenating unicode and byte (specifically, unicode on left, and byte on right)

Add test cases in test_py3kwarn.py to test warning

<img width="1908" height="209" alt="image" src="https://github.com/user-attachments/assets/fe5a2446-7beb-4fef-9339-b456d200f9d4" />
