### PR TITLE
Use Bookworm for CI.

### DIFF
--- a/.buildbot_dockerfile_debian
+++ b/.buildbot_dockerfile_debian
@@ -1,0 +1,9 @@
+FROM debian:bookworm
+ARG CI_UID
+RUN useradd -m -u ${CI_UID} ci
+RUN apt-get update && \
+    apt-get -y install build-essential curl procps file
+WORKDIR /ci
+RUN chown ${CI_UID}:${CI_UID} .
+COPY --chown=${CI_UID}:${CI_UID} . .
+CMD sh -x .buildbot.sh


### PR DESCRIPTION
At least for now, it seems that newer Debians (and the compilers they ship) find warnings that we don't want to deal with.